### PR TITLE
Clean up CypherGraph API

### DIFF
--- a/src/main/scala/org/opencypher/spark/api/graph/CypherGraph.scala
+++ b/src/main/scala/org/opencypher/spark/api/graph/CypherGraph.scala
@@ -1,7 +1,5 @@
 package org.opencypher.spark.api.graph
 
-import org.opencypher.spark.api.expr.{Expr, Var}
-import org.opencypher.spark.api.ir.QueryModel
 import org.opencypher.spark.api.record.CypherRecords
 import org.opencypher.spark.api.schema.Schema
 
@@ -17,17 +15,7 @@ trait CypherGraph {
 
   def schema: Schema
 
-  // TODO: This opens up for someone to send a wrongly typed variable here -- name here, type on inside?
-  def nodes(v: Var): Records
-  def relationships(v: Var): Records
+  def nodes(name: String): Records
+  def relationships(name: String): Records
 
-//  def filterNodes()
-//  def filterRelationships()
-
-//  def union(other: Graph): Graph
-//  def intersect(other: Graph): Graph
-
-  // TODO
-  // other attributes, other views (constituents, triplets, domain)
 }
-

--- a/src/main/scala/org/opencypher/spark/api/spark/SparkCypherGraph.scala
+++ b/src/main/scala/org/opencypher/spark/api/spark/SparkCypherGraph.scala
@@ -4,6 +4,7 @@ import org.opencypher.spark.api.expr.Var
 import org.opencypher.spark.api.graph.CypherGraph
 import org.opencypher.spark.api.record.{OpaqueField, RecordHeader}
 import org.opencypher.spark.api.schema.Schema
+import org.opencypher.spark.api.types.{CTNode, CTRelationship}
 
 trait SparkCypherGraph extends CypherGraph {
 
@@ -23,11 +24,11 @@ object SparkCypherGraph {
     graphSpace: SparkGraphSpace
   ) extends SparkCypherGraph {
 
-    override def nodes(v: Var): SparkCypherRecords =
-      SparkCypherRecords.empty(RecordHeader.from(OpaqueField(v)))(graphSpace)
+    override def nodes(name: String): SparkCypherRecords =
+      SparkCypherRecords.empty(RecordHeader.from(OpaqueField(Var(name)(CTNode))))(graphSpace)
 
-    override def relationships(v: Var): SparkCypherRecords =
-      SparkCypherRecords.empty(RecordHeader.from(OpaqueField(v)))(graphSpace)
+    override def relationships(name: String): SparkCypherRecords =
+      SparkCypherRecords.empty(RecordHeader.from(OpaqueField(Var(name)(CTRelationship))))(graphSpace)
 
     override def space = graphSpace
     override def schema = Schema.empty

--- a/src/main/scala/org/opencypher/spark/impl/physical/PhysicalPlanner.scala
+++ b/src/main/scala/org/opencypher/spark/impl/physical/PhysicalPlanner.scala
@@ -66,7 +66,7 @@ class PhysicalPlanner extends DirectCompilationStage[FlatOperator, SparkCypherRe
         val rhs = inner(targetOp)
 
         val g = lhs.graphs(op.inGraph.name)
-        val relationships = g.relationships(rel)
+        val relationships = g.relationships(rel.name)
         val relRhs = InternalResult(relationships, lhs.graphs).typeFilter(rel, types.relTypes.map(tokens.relTypeRef), relHeader)
 
         val relAndTarget = relRhs.joinTarget(rhs).on(rel)(target)

--- a/src/main/scala/org/opencypher/spark/impl/physical/PhysicalProducer.scala
+++ b/src/main/scala/org/opencypher/spark/impl/physical/PhysicalProducer.scala
@@ -28,7 +28,7 @@ class PhysicalProducer(context: RuntimeContext) {
     def nodeScan(inGraph: NamedLogicalGraph, v: Var, labels: EveryNode, header: RecordHeader): InternalResult = {
       val graph = prev.graphs(inGraph.name)
 
-      val records = graph.nodes(v).reorder(header)
+      val records = graph.nodes(v.name).reorder(header)
 
       // TODO: Should not discard prev records here
       prev.mapRecords(_ => records)
@@ -37,7 +37,7 @@ class PhysicalProducer(context: RuntimeContext) {
     def relationshipScan(inGraph: NamedLogicalGraph, v: Var, header: RecordHeader): InternalResult = {
       val graph = prev.graphs(inGraph.name)
 
-      val records = graph.relationships(v).reorder(header)
+      val records = graph.relationships(v.name).reorder(header)
 
       // TODO: Should not discard prev records here
       prev.mapRecords(_ => records)

--- a/src/test/scala/org/opencypher/spark/GraphMatchingTestSupport.scala
+++ b/src/test/scala/org/opencypher/spark/GraphMatchingTestSupport.scala
@@ -3,8 +3,7 @@ package org.opencypher.spark
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.{Row, SparkSession}
 import org.opencypher.spark.api.classes.Cypher
-import org.opencypher.spark.api.expr.{Expr, HasLabel, Property, Var}
-import org.opencypher.spark.api.ir.QueryModel
+import org.opencypher.spark.api.expr.{HasLabel, Property, Var}
 import org.opencypher.spark.api.ir.global.TokenRegistry
 import org.opencypher.spark.api.record.{FieldSlotContent, RecordHeader}
 import org.opencypher.spark.api.schema.Schema
@@ -30,11 +29,11 @@ trait GraphMatchingTestSupport extends TestSession.Fixture {
 
   implicit class GraphMatcher(graph: SparkCypherGraph) {
     def shouldMatch(expectedGraph: SparkCypherGraph): Assertion = {
-      val expectedNodeIds = expectedGraph.nodes(Var("n")(CTNode)).data.select("n").collect().map(_.getLong(0)).toSet
-      val expectedRelIds = expectedGraph.relationships(Var("r")(CTRelationship)).data.select("r").collect().map(_.getLong(0)).toSet
+      val expectedNodeIds = expectedGraph.nodes("n").data.select("n").collect().map(_.getLong(0)).toSet
+      val expectedRelIds = expectedGraph.relationships("r").data.select("r").collect().map(_.getLong(0)).toSet
 
-      val actualNodeIds = graph.nodes(Var("n")(CTNode)).data.select("n").collect().map(_.getLong(0)).toSet
-      val actualRelIds = graph.relationships(Var("r")(CTRelationship)).data.select("r").collect().map(_.getLong(0)).toSet
+      val actualNodeIds = graph.nodes("n").data.select("n").collect().map(_.getLong(0)).toSet
+      val actualRelIds = graph.relationships("r").data.select("r").collect().map(_.getLong(0)).toSet
 
       expectedNodeIds should equal(actualNodeIds)
       expectedRelIds should equal(actualRelIds)
@@ -86,9 +85,9 @@ trait GraphMatchingTestSupport extends TestSession.Fixture {
         }
       }
 
-      override def nodes(v: Var): SparkCypherRecords = {
+      override def nodes(name: String): SparkCypherRecords = {
 
-        val header = RecordHeader.nodeFromSchema(v, schema, space.tokens.registry)
+        val header = RecordHeader.nodeFromSchema(Var(name)(CTNode), schema, space.tokens.registry)
 
         val data = {
           val nodes = queryGraph.getVertices.asScala.map { v =>
@@ -113,9 +112,9 @@ trait GraphMatchingTestSupport extends TestSession.Fixture {
         SparkCypherRecords.create(header, data)(space)
       }
 
-      override def relationships(v: Var): SparkCypherRecords = {
+      override def relationships(name: String): SparkCypherRecords = {
 
-        val header = RecordHeader.relationshipFromSchema(v, schema, space.tokens.registry)
+        val header = RecordHeader.relationshipFromSchema(Var(name)(CTRelationship), schema, space.tokens.registry)
 
         val data = {
           val rels = queryGraph.getEdges.asScala.map { e =>

--- a/src/test/scala/org/opencypher/spark/impl/instances/SparkCypherRecordsAcceptanceTest.scala
+++ b/src/test/scala/org/opencypher/spark/impl/instances/SparkCypherRecordsAcceptanceTest.scala
@@ -1,8 +1,5 @@
 package org.opencypher.spark.impl.instances
 
-import org.opencypher.spark.api.expr._
-import org.opencypher.spark.api.ir.global.{Label, PropertyKey}
-import org.opencypher.spark.api.record._
 import org.opencypher.spark.api.schema.Schema
 import org.opencypher.spark.api.spark.{SparkCypherRecords, SparkGraphSpace}
 import org.opencypher.spark.api.types._

--- a/src/test/scala/org/opencypher/spark/impl/load/SparkGraphSpaceTest.scala
+++ b/src/test/scala/org/opencypher/spark/impl/load/SparkGraphSpaceTest.scala
@@ -1,17 +1,16 @@
 package org.opencypher.spark.impl.load
 
 import org.apache.spark.sql.types._
-import org.opencypher.spark.api.expr.Var
 import org.opencypher.spark.api.schema.Schema
 import org.opencypher.spark.api.spark.{SparkCypherGraph, SparkGraphSpace}
 import org.opencypher.spark.api.types._
-import org.opencypher.spark.{TestSuiteImpl, TestSession}
+import org.opencypher.spark.{TestSession, TestSuiteImpl}
 
 class SparkGraphSpaceTest extends TestSuiteImpl with TestSession.Fixture {
 
   implicit class RichGraph(val graph: SparkCypherGraph) {
-    def nodes() = graph.nodes(Var("n")(CTNode))
-    def rels() = graph.relationships(Var("r")(CTRelationship))
+    def nodes() = graph.nodes("n")
+    def rels() = graph.relationships("r")
   }
 
   test("import nodes from neo") {


### PR DESCRIPTION
Now takes the name of a variable for a node scan, disallowing sending a
badly typed variable as a parameter.