### PR TITLE
Flatten UNION graph structure

### DIFF
--- a/src/main/scala/org/opencypher/caps/api/spark/CAPSUnionGraph.scala
+++ b/src/main/scala/org/opencypher/caps/api/spark/CAPSUnionGraph.scala
@@ -65,6 +65,10 @@ final case class CAPSUnionGraph(graphs: CAPSGraph*)
     alignedScans.reduceOption(_ unionAll(targetHeader, _)).map(_.distinct).getOrElse(CAPSRecords.empty(targetHeader))
   }
 
-  // TODO: Flatten
-  override def union(other: CAPSGraph) = CAPSUnionGraph(this, other)
+  override def union(other: CAPSGraph): CAPSUnionGraph = other match {
+    case other: CAPSUnionGraph =>
+      CAPSUnionGraph(graphs ++ other.graphs: _*)
+    case _ =>
+      CAPSUnionGraph(graphs :+ other: _*)
+  }
 }


### PR DESCRIPTION
This avoids chained computations of UNIONs (f.e. distinct())