### PR TITLE
Tree node fixes

### DIFF
--- a/caps-core/src/main/scala/org/opencypher/caps/impl/common/TreeNode.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/common/TreeNode.scala
@@ -108,7 +108,7 @@ abstract class TreeNode[T <: TreeNode[T]: ClassTag] extends Product with Travers
     * @param depth indentation depth used by the recursive call
     * @return tree-style representation of that node and all (grand-)children
     */
-  def pretty(depth: Int = 0): String = {
+  def pretty(implicit depth: Int = 0): String = {
 
     def prefix(depth: Int): String = ("· " * depth) + "|-"
 
@@ -119,21 +119,19 @@ abstract class TreeNode[T <: TreeNode[T]: ClassTag] extends Product with Travers
   }
 
   /**
-    * Concatenates all arguments of this tree node excluding the children.
+    * Turns all arguments in `args` into a string that describes the arguments.
     *
     * @return argument string
     */
-  def argString: String =
-    args.flatMap {
-      case tn: T if containsChild(tn) => None // Don't print children
-      case other => other.toString
-    }.mkString(", ")
+  def argString: String = args.mkString(", ")
 
   /**
-    * Arguments that should be printed. Can return `productIterator` to opt into printing all
-    * arguments.
+    * Arguments that should be printed. The default implementation excludes children.
     */
-  def args: Iterator[Any] = Iterator.empty
+  def args: Iterator[Any] = productIterator.flatMap {
+    case tn: T if containsChild(tn) => None // Don't print children
+    case other                      => Some(other.toString)
+  }
 
   override def toString = s"${getClass.getSimpleName}${if (argString.isEmpty) "" else s"($argString)"}"
 }

--- a/caps-core/src/test/scala/org/opencypher/caps/impl/common/ScalaTestHelpers.scala
+++ b/caps-core/src/test/scala/org/opencypher/caps/impl/common/ScalaTestHelpers.scala
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opencypher.caps.impl.logical
+package org.opencypher.caps.impl.common
 
 import org.opencypher.caps.impl.common.AsCode._
+import org.opencypher.caps.impl.common.MatchHelper._
 import org.scalatest.matchers.{MatchResult, Matcher}
-import org.opencypher.caps.impl.logical.MatchHelper._
 
 /**
-  * A substitute for the ScalaTest matcher that crashes when checking if some of our larger trees are equal.
+  * A substitute for the ScalaTest `theSameInstanceAs` matcher that crashes on some of our trees.
+  */
+case class referenceEqual(right: AnyRef) extends Matcher[AnyRef] {
+  override def apply(left: AnyRef): MatchResult = {
+    MatchResult(if (left == null) right == null else left.eq(right), s"$left was not the same instance as $right", "")
+  }
+}
+
+/**
+  * A substitute for the ScalaTest `equal` matcher that crashes on some of our trees.
   */
 case class equalWithTracing(right: Any) extends Matcher[Any] {
   override def apply(left: Any): MatchResult = {
@@ -93,7 +102,7 @@ case class equalWithTracing(right: Any) extends Matcher[Any] {
   def failure(msg: String) = MatchResult(false, msg, "")
 
   def notEqual(l: Any, r: Any): Unit = {
-//    println(s"${AsCode(l)} did NOT equal ${AsCode(r)}")
+    //    println(s"${AsCode(l)} did NOT equal ${AsCode(r)}")
   }
 
 }

--- a/caps-core/src/test/scala/org/opencypher/caps/impl/common/TreeNodeTest.scala
+++ b/caps-core/src/test/scala/org/opencypher/caps/impl/common/TreeNodeTest.scala
@@ -68,12 +68,12 @@ class TreeNodeTest extends FunSuite with Matchers {
   }
 
   test("pretty") {
-    calculation.pretty should equal("""|-Add
-· |-Number(5)
-· |-Add
-· · |-Number(4)
-· · |-Number(3)
-""")
+    calculation.pretty should equal("""#|-Add
+                                       #· |-Number(5)
+                                       #· |-Add
+                                       #· · |-Number(4)
+                                       #· · |-Number(3)
+                                       #""".stripMargin('#'))
   }
 
   test("copy with the same children returns the same instance") {

--- a/caps-core/src/test/scala/org/opencypher/caps/impl/common/TreeNodeTest.scala
+++ b/caps-core/src/test/scala/org/opencypher/caps/impl/common/TreeNodeTest.scala
@@ -45,8 +45,8 @@ class TreeNodeTest extends FunSuite with Matchers {
   test("rewrite") {
     val addNoops: PartialFunction[CalcExpr, CalcExpr] = {
       case Add(n1: Number, n2: Number) => Add(Noop(n1), Noop(n2))
-      case Add(n1: Number, n2)         => Add(Noop(n1), n2)
-      case Add(n1, n2: Number)         => Add(n1, Noop(n2))
+      case Add(n1: Number, n2) => Add(Noop(n1), n2)
+      case Add(n1, n2: Number) => Add(n1, Noop(n2))
     }
 
     val expected = Add(Noop(Number(5)), Add(Noop(Number(4)), Noop(Number(3))))
@@ -55,6 +55,25 @@ class TreeNodeTest extends FunSuite with Matchers {
 
     val up = calculation.transformUp(addNoops)
     up should equal(expected)
+  }
+
+  test("arg string") {
+    Number(12).argString should equal("12")
+    Add(Number(1), Number(2)).argString should equal("")
+  }
+
+  test("to string") {
+    Number(12).toString should equal("Number(12)")
+    Add(Number(1), Number(2)).toString should equal("Add")
+  }
+
+  test("pretty") {
+    calculation.pretty should equal("""|-Add
+· |-Number(5)
+· |-Add
+· · |-Number(4)
+· · |-Number(3)
+""")
   }
 
   abstract class CalcExpr extends AbstractTreeNode[CalcExpr] {

--- a/caps-core/src/test/scala/org/opencypher/caps/impl/common/TreeNodeTest.scala
+++ b/caps-core/src/test/scala/org/opencypher/caps/impl/common/TreeNodeTest.scala
@@ -44,12 +44,12 @@ class TreeNodeTest extends FunSuite with Matchers {
 
   test("rewrite") {
     val addNoops: PartialFunction[CalcExpr, CalcExpr] = {
-      case Add(n1: Number, n2: Number) => Add(Noop(n1), Noop(n2))
-      case Add(n1: Number, n2) => Add(Noop(n1), n2)
-      case Add(n1, n2: Number) => Add(n1, Noop(n2))
+      case Add(n1: Number, n2: Number) => Add(NoOp(n1), NoOp(n2))
+      case Add(n1: Number, n2)         => Add(NoOp(n1), n2)
+      case Add(n1, n2: Number)         => Add(n1, NoOp(n2))
     }
 
-    val expected = Add(Noop(Number(5)), Add(Noop(Number(4)), Noop(Number(3))))
+    val expected = Add(NoOp(Number(5)), Add(NoOp(Number(4)), NoOp(Number(3))))
     val down = calculation.transformDown(addNoops)
     down should equal(expected)
 
@@ -76,6 +76,10 @@ class TreeNodeTest extends FunSuite with Matchers {
 """)
   }
 
+  test("copy with the same children returns the same instance") {
+    calculation.withNewChildren(Seq(calculation.left, calculation.right)) should referenceEqual(calculation)
+  }
+
   abstract class CalcExpr extends AbstractTreeNode[CalcExpr] {
     def eval: Int
   }
@@ -88,7 +92,7 @@ class TreeNodeTest extends FunSuite with Matchers {
     def eval = v
   }
 
-  case class Noop(in: CalcExpr) extends CalcExpr {
+  case class NoOp(in: CalcExpr) extends CalcExpr {
     def eval = in.eval
   }
 

--- a/caps-core/src/test/scala/org/opencypher/caps/impl/logical/LogicalOptimizerTest.scala
+++ b/caps-core/src/test/scala/org/opencypher/caps/impl/logical/LogicalOptimizerTest.scala
@@ -18,6 +18,7 @@ package org.opencypher.caps.impl.logical
 import org.opencypher.caps.api.expr._
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types.{CTNode, _}
+import org.opencypher.caps.impl.common.equalWithTracing
 import org.opencypher.caps.ir.api._
 import org.opencypher.caps.ir.impl.IrTestSuite
 

--- a/caps-core/src/test/scala/org/opencypher/caps/impl/logical/LogicalPlannerTest.scala
+++ b/caps-core/src/test/scala/org/opencypher/caps/impl/logical/LogicalPlannerTest.scala
@@ -20,16 +20,17 @@ import java.net.URI
 import org.opencypher.caps.api.expr._
 import org.opencypher.caps.api.io.PersistMode
 import org.opencypher.caps.api.record.{ProjectedExpr, ProjectedField}
-import org.opencypher.caps.api.schema.{ImpliedLabels, LabelCombinations, PropertyKeyMap, Schema}
+import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.spark.CAPSGraph
 import org.opencypher.caps.api.spark.io.CAPSGraphSource
 import org.opencypher.caps.api.types._
 import org.opencypher.caps.api.value.{CypherBoolean, CypherInteger, CypherString}
+import org.opencypher.caps.impl.common.{MatchHelper, equalWithTracing}
 import org.opencypher.caps.impl.logical
 import org.opencypher.caps.impl.util.toVar
 import org.opencypher.caps.ir.api._
 import org.opencypher.caps.ir.api.block._
-import org.opencypher.caps.ir.api.pattern.{AllGiven, DirectedRelationship, Pattern}
+import org.opencypher.caps.ir.api.pattern.{DirectedRelationship, Pattern}
 import org.opencypher.caps.ir.impl.IrTestSuite
 import org.opencypher.caps.toField
 import org.scalatest.matchers._
@@ -109,9 +110,8 @@ class LogicalPlannerTest extends IrTestSuite {
         Var("a.name")(CTNull),
         Property(Var("a")(CTNode(Set("Administrator"))), PropertyKey("name"))(CTNull)),
       Filter(
-        Equals(
-          Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull),
-          Param("foo")(CTString))(CTBoolean),
+        Equals(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull), Param("foo")(CTString))(
+          CTBoolean),
         Project(
           ProjectedExpr(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull)),
           Filter(
@@ -159,9 +159,8 @@ class LogicalPlannerTest extends IrTestSuite {
           Set(
             HasLabel(Var("a")(CTNode), Label("Administrator"))(CTBoolean),
             HasLabel(Var("g")(CTNode), Label("Group"))(CTBoolean),
-            Equals(
-              Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull),
-              Param("foo")(CTString))(CTBoolean)
+            Equals(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull), Param("foo")(CTString))(
+              CTBoolean)
           )
         )
       ),
@@ -170,9 +169,8 @@ class LogicalPlannerTest extends IrTestSuite {
         Set(
           HasLabel(Var("a")(CTNode), Label("Administrator"))(CTBoolean),
           HasLabel(Var("g")(CTNode), Label("Group"))(CTBoolean),
-          Equals(
-            Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull),
-            Param("foo")(CTString))(CTBoolean)
+          Equals(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTNull), Param("foo")(CTString))(
+            CTBoolean)
         )
       )
     )
@@ -194,9 +192,8 @@ class LogicalPlannerTest extends IrTestSuite {
         Var("a.name")(CTFloat),
         Property(Var("a")(CTNode(Set("Administrator"))), PropertyKey("name"))(CTFloat)),
       Filter(
-        Equals(
-          Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString),
-          Param("foo")(CTString))(CTBoolean),
+        Equals(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString), Param("foo")(CTString))(
+          CTBoolean),
         Project(
           ProjectedExpr(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString)),
           Filter(
@@ -266,9 +263,8 @@ class LogicalPlannerTest extends IrTestSuite {
           Set(
             HasLabel(Var("a")(CTNode), Label("Administrator"))(CTBoolean),
             HasLabel(Var("g")(CTNode), Label("Group"))(CTBoolean),
-            Equals(
-              Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString),
-              Param("foo")(CTString))(CTBoolean)
+            Equals(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString), Param("foo")(CTString))(
+              CTBoolean)
           )
         )
       ),
@@ -277,9 +273,8 @@ class LogicalPlannerTest extends IrTestSuite {
         Set(
           HasLabel(Var("a")(CTNode), Label("Administrator"))(CTBoolean),
           HasLabel(Var("g")(CTNode), Label("Group"))(CTBoolean),
-          Equals(
-            Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString),
-            Param("foo")(CTString))(CTBoolean)
+          Equals(Property(Var("g")(CTNode(Set("Group"))), PropertyKey("name"))(CTString), Param("foo")(CTString))(
+            CTBoolean)
         )
       )
     )


### PR DESCRIPTION
Fixes the string representation of trees, adds tests to verify the string representation stays pretty, and slightly improves caching of reflected copy methods by using ThreadLocal instead of a concurrent map.