### PR TITLE
Improve TreeNode implementation

### DIFF
--- a/caps-core/src/main/scala/org/opencypher/caps/impl/common/AbstractTreeNode.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/common/AbstractTreeNode.scala
@@ -26,33 +26,39 @@ import scala.reflect.ClassTag
   * Requirements: All child nodes need to be individual constructor parameters and their order
   * in children is their order in the constructor. Every constructor parameter of type `T` is
   * assumed to be a child node.
+  *
+  * This class caches values that are expensive to recompute. It also uses array operations instead of
+  * Scala collections, both for improved performance as well as to save stack frames, which allows to operate on
+  * trees that are several thousand nodes high.
   */
 abstract class AbstractTreeNode[T <: TreeNode[T]: ClassTag] extends TreeNode[T] {
   self: T =>
 
-  override lazy val children: Seq[T] = productIterator.toVector.collect { case t: T => t }
+  override final val children: Array[T] = {
+    val constructorParamLength = productArity
+    val childrenArray = new Array[T](constructorParamLength)
+    var i = 0
+    var ci = 0
+    while (i < constructorParamLength) {
+      val pi = productElement(i)
+      pi match {
+        case c: T =>
+          childrenArray(ci) = c
+          ci += 1
+        case _ =>
+      }
+      i += 1
+    }
+    val properSizedChildren = new Array[T](ci)
+    System.arraycopy(childrenArray, 0, properSizedChildren, 0, ci)
+    properSizedChildren
+  }
 
-  /**
-    * Cache children as a set for faster rewrites.
-    */
-  override lazy val childrenAsSet = children.toSet
-
-  override def withNewChildren(newChildren: Seq[T]): T = {
-    val newAsVector = newChildren.toVector
-    if (children == newAsVector) {
+  @inline override final def withNewChildren(newChildren: Array[T]): T = {
+    if (sameAsCurrentChildren(newChildren)) {
       self
     } else {
-      require(
-        children.length == newAsVector.length,
-        s"invalid children for $productPrefix: ${newAsVector.mkString(", ")}")
-      val substitutions = children.toList.zip(newAsVector)
-      val (updatedConstructorParams, _) = productIterator.foldLeft((Vector.empty[Any], substitutions)) {
-        case ((result, remainingSubs), next) =>
-          remainingSubs match {
-            case (oldC, newC) :: tail if next == oldC => (result :+ newC, tail)
-            case _                                    => (result :+ next, remainingSubs)
-          }
-      }
+      val updatedConstructorParams = updateConstructorParams(newChildren)
       val copyMethod = AbstractTreeNode.copyMethod(self)
       try {
         copyMethod(updatedConstructorParams: _*).asInstanceOf[T]
@@ -68,36 +74,173 @@ abstract class AbstractTreeNode[T <: TreeNode[T]: ClassTag] extends TreeNode[T] 
     }
   }
 
+  override final lazy val hashCode: Int = super.hashCode
+
+  final lazy val childrenAsSet = children.toSet
+
+  override final lazy val size: Int = {
+    val childrenLength = children.length
+    var i = 0
+    var result = 1
+    while (i < childrenLength) {
+      result += children(i).size
+      i += 1
+    }
+    result
+  }
+
+  final override lazy val height: Int = {
+    val childrenLength = children.length
+    var i = 0
+    var result = 0
+    while (i < childrenLength) {
+      result = math.max(result, children(i).height)
+      i += 1
+    }
+    result + 1
+  }
+
+  @inline final override def map[O <: TreeNode[O]: ClassTag](f: T => O): O = {
+    val childrenLength = children.length
+    if (childrenLength == 0) {
+      f(self)
+    } else {
+      val mappedChildren = new Array[O](childrenLength)
+      var i = 0
+      while (i < childrenLength) {
+        mappedChildren(i) = f(children(i))
+        i += 1
+      }
+      f(self).withNewChildren(mappedChildren)
+    }
+  }
+
+  @inline final override def foreach[O](f: T => O): Unit = {
+    f(this)
+    val childrenLength = children.length
+    var i = 0
+    while (i < childrenLength) {
+      children(i).foreach(f)
+      i += 1
+    }
+  }
+
+  @inline final override def containsTree(other: T): Boolean = {
+    if (self == other) {
+      true
+    } else {
+      val childrenLength = children.length
+      var i = 0
+      while (i < childrenLength && !children(i).containsTree(other)) i += 1
+      i != childrenLength
+    }
+  }
+
+  @inline final override def containsChild(other: T): Boolean = {
+    childrenAsSet.contains(other)
+  }
+
+  @inline final override def transformUp(rule: PartialFunction[T, T]): T = {
+    val childrenLength = children.length
+    val afterChildren = if (childrenLength == 0) {
+      self
+    } else {
+      val updatedChildren = {
+        val childrenCopy = new Array[T](childrenLength)
+        var i = 0
+        while (i < childrenLength) {
+          childrenCopy(i) = children(i).transformUp(rule)
+          i += 1
+        }
+        childrenCopy
+      }
+      withNewChildren(updatedChildren)
+    }
+    if (rule.isDefinedAt(afterChildren)) rule(afterChildren) else afterChildren
+  }
+
+  @inline final override def transformDown(rule: PartialFunction[T, T]): T = {
+    val afterSelf = if (rule.isDefinedAt(self)) rule(self) else self
+    val childrenLength = afterSelf.children.length
+    if (childrenLength == 0) {
+      afterSelf
+    } else {
+      val updatedChildren = {
+        val childrenCopy = new Array[T](childrenLength)
+        var i = 0
+        while (i < childrenLength) {
+          childrenCopy(i) = afterSelf.children(i).transformDown(rule)
+          i += 1
+        }
+        childrenCopy
+      }
+      afterSelf.withNewChildren(updatedChildren)
+    }
+  }
+
+  @inline private final def updateConstructorParams(newChildren: Array[T]): Array[Any] = {
+    require(
+      children.length == newChildren.length,
+      s"invalid children for $productPrefix: ${newChildren.mkString(", ")}")
+    val parameterArrayLength = productArity
+    val parameterArray = new Array[Any](parameterArrayLength)
+    var productIndex = 0
+    var childrenIndex = 0
+    while (productIndex < parameterArrayLength) {
+      val currentProductElement = productElement(productIndex)
+      if (currentProductElement == children(childrenIndex)) {
+        parameterArray(productIndex) = newChildren(childrenIndex)
+        childrenIndex += 1
+      } else {
+        parameterArray(productIndex) = currentProductElement
+      }
+      productIndex += 1
+    }
+    parameterArray
+  }
+
+  @inline private final def sameAsCurrentChildren(newChildren: Array[T]): Boolean = {
+    val childrenLength = children.length
+    if (childrenLength != newChildren.length) {
+      false
+    } else {
+      var i = 0
+      while (i < childrenLength && children(i) == newChildren(i)) i += 1
+      i == childrenLength
+    }
+  }
+
 }
 
 /**
-  * Caches an instance of the copy method per case class type and thread.
+  * Caches an instance of the copy method per case class type.
   */
 object AbstractTreeNode {
 
   import scala.reflect.runtime.universe
   import scala.reflect.runtime.universe._
 
-  private lazy val cachedCopyMethods = new ThreadLocal[Map[Class[_], MethodMirror]]() {
-    override def initialValue = Map.empty[Class[_], MethodMirror]
-  }
+  // No synchronization required: No problem if a cache entry is lost due to a concurrent write.
+  @volatile private var cachedCopyMethods = Map.empty[Class[_], MethodMirror]
 
-  private lazy val mirror = universe.runtimeMirror(getClass.getClassLoader)
+  private final lazy val mirror = universe.runtimeMirror(getClass.getClassLoader)
 
-  protected def copyMethod[T <: TreeNode[T]](instance: AbstractTreeNode[T]): MethodMirror = {
+  @inline protected final def copyMethod(instance: AbstractTreeNode[_]): MethodMirror = {
     val instanceClass = instance.getClass
-    val cacheMap = cachedCopyMethods.get()
-    cacheMap.getOrElse(
+    cachedCopyMethods.getOrElse(
       instanceClass, {
-        val instanceMirror = mirror.reflect(instance)
-        val tpe = instanceMirror.symbol.asType.toType
-        val copyMethodSymbol = tpe.decl(TermName("copy")).asMethod
-        val copyMethod = instanceMirror.reflectMethod(copyMethodSymbol)
-        val updatedCacheMap = cacheMap.updated(instanceClass, copyMethod)
-        cachedCopyMethods.set(updatedCacheMap)
+        val copyMethod = reflectCopyMethod(instance)
+        cachedCopyMethods = cachedCopyMethods.updated(instanceClass, copyMethod)
         copyMethod
       }
     )
+  }
+
+  @inline private final def reflectCopyMethod(instance: Object): MethodMirror = {
+    val instanceMirror = mirror.reflect(instance)
+    val tpe = instanceMirror.symbol.asType.toType
+    val copyMethodSymbol = tpe.decl(TermName("copy")).asMethod
+    instanceMirror.reflectMethod(copyMethodSymbol)
   }
 
 }

--- a/caps-core/src/main/scala/org/opencypher/caps/impl/common/AbstractTreeNode.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/common/AbstractTreeNode.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
   * Scala collections, both for improved performance as well as to save stack frames, which allows to operate on
   * trees that are several thousand nodes high.
   */
-abstract class AbstractTreeNode[T <: TreeNode[T]: ClassTag] extends TreeNode[T] {
+abstract class AbstractTreeNode[T <: AbstractTreeNode[T]: ClassTag] extends TreeNode[T] {
   self: T =>
 
   override final val children: Array[T] = {
@@ -183,12 +183,13 @@ abstract class AbstractTreeNode[T <: TreeNode[T]: ClassTag] extends TreeNode[T] 
       children.length == newChildren.length,
       s"invalid children for $productPrefix: ${newChildren.mkString(", ")}")
     val parameterArrayLength = productArity
+    val childrenLength = children.length
     val parameterArray = new Array[Any](parameterArrayLength)
     var productIndex = 0
     var childrenIndex = 0
     while (productIndex < parameterArrayLength) {
       val currentProductElement = productElement(productIndex)
-      if (currentProductElement == children(childrenIndex)) {
+      if (childrenIndex < childrenLength && currentProductElement == children(childrenIndex)) {
         parameterArray(productIndex) = newChildren(childrenIndex)
         childrenIndex += 1
       } else {

--- a/caps-core/src/main/scala/org/opencypher/caps/impl/common/TreeNode.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/common/TreeNode.scala
@@ -22,34 +22,20 @@ abstract class TreeNode[T <: TreeNode[T]: ClassTag] extends Product with Travers
 
   self: T =>
 
-  def withNewChildren(newChildren: Seq[T]): T
+  def withNewChildren(newChildren: Array[T]): T
 
-  def children: Seq[T] = Seq.empty
+  def children: Array[T] = Array.empty
 
-  /**
-    * Explicit accessor to the set of children. This allows for an implementation to cache this,
-    * which can speed up rewrites.
-    */
-  def childrenAsSet: Set[T] = children.toSet
-
-  // Optimization: Cache hash code, speeds up repeated computations over high trees.
-  override lazy val hashCode: Int = MurmurHash3.productHash(self)
+  override def hashCode: Int = MurmurHash3.productHash(self)
 
   def arity: Int = children.length
 
   def isLeaf: Boolean = height == 1
 
-  lazy val height: Int = if (children.isEmpty) 1 else children.map(_.height).max + 1
+  def height: Int = if (children.isEmpty) 1 else children.map(_.height).max + 1
 
-  def map[O <: TreeNode[O]](f: T => O): O = {
+  def map[O <: TreeNode[O]: ClassTag](f: T => O): O = {
     f(self).withNewChildren(children.map(f))
-  }
-
-  override def foldLeft[O](initial: O)(f: (O, T) => O): O = {
-    children.foldLeft(f(initial, this)) {
-      case (agg, nextChild) =>
-        nextChild.foldLeft(agg)(f)
-    }
   }
 
   override def foreach[O](f: T => O): Unit = {
@@ -74,7 +60,7 @@ abstract class TreeNode[T <: TreeNode[T]: ClassTag] extends Product with Travers
     * @return true, iff `other` is a direct child of this tree
     */
   def containsChild(other: T): Boolean = {
-    childrenAsSet.contains(other)
+    children.contains(other)
   }
 
   /**

--- a/caps-core/src/main/scala/org/opencypher/caps/impl/flat/FlatOperator.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/flat/FlatOperator.scala
@@ -27,14 +27,14 @@ sealed abstract class FlatOperator extends AbstractTreeNode[FlatOperator] {
   def sourceGraph: LogicalGraph
 }
 
-sealed trait BinaryFlatOperator extends FlatOperator {
+sealed abstract class BinaryFlatOperator extends FlatOperator {
   def lhs: FlatOperator
   def rhs: FlatOperator
 
   override def sourceGraph: LogicalGraph = lhs.sourceGraph
 }
 
-sealed trait TernaryFlatOperator extends FlatOperator {
+sealed abstract class TernaryFlatOperator extends FlatOperator {
   def first: FlatOperator
   def second: FlatOperator
   def third: FlatOperator
@@ -42,13 +42,13 @@ sealed trait TernaryFlatOperator extends FlatOperator {
   override def sourceGraph: LogicalGraph = first.sourceGraph
 }
 
-sealed trait StackingFlatOperator extends FlatOperator {
+sealed abstract class StackingFlatOperator extends FlatOperator {
   def in: FlatOperator
 
   override def sourceGraph: LogicalGraph = in.sourceGraph
 }
 
-sealed trait FlatLeafOperator extends FlatOperator
+sealed abstract class FlatLeafOperator extends FlatOperator
 
 final case class NodeScan(node: Var, in: FlatOperator, header: RecordHeader) extends StackingFlatOperator
 

--- a/caps-core/src/main/scala/org/opencypher/caps/impl/logical/LogicalOperator.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/logical/LogicalOperator.scala
@@ -23,8 +23,7 @@ import org.opencypher.caps.impl.common.AbstractTreeNode
 import org.opencypher.caps.ir.api.block.SortItem
 import org.opencypher.caps.ir.api.{Label, SolvedQueryModel}
 
-
-sealed trait LogicalOperator extends AbstractTreeNode[LogicalOperator] {
+sealed abstract class LogicalOperator extends AbstractTreeNode[LogicalOperator] {
   def solved: SolvedQueryModel[Expr]
 
   val fields: Set[Var]
@@ -52,13 +51,13 @@ case class ConstructedNode(v: Var, labels: Set[Label]) extends ConstructedEntity
 
 case class ConstructedRelationship(v: Var, source: Var, target: Var, typ: String) extends ConstructedEntity
 
-sealed trait StackingLogicalOperator extends LogicalOperator {
+sealed abstract class StackingLogicalOperator extends LogicalOperator {
   def in: LogicalOperator
 
   override def sourceGraph: LogicalGraph = in.sourceGraph
 }
 
-sealed trait BinaryLogicalOperator extends LogicalOperator {
+sealed abstract class BinaryLogicalOperator extends LogicalOperator {
   def lhs: LogicalOperator
 
   def rhs: LogicalOperator
@@ -70,7 +69,7 @@ sealed trait BinaryLogicalOperator extends LogicalOperator {
   override def sourceGraph: LogicalGraph = rhs.sourceGraph
 }
 
-sealed trait LogicalLeafOperator extends LogicalOperator
+sealed abstract class LogicalLeafOperator extends LogicalOperator
 
 final case class NodeScan(node: Var, in: LogicalOperator, solved: SolvedQueryModel[Expr])
     extends StackingLogicalOperator {

--- a/caps-core/src/main/scala/org/opencypher/caps/impl/logical/LogicalOptimizer.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/logical/LogicalOptimizer.scala
@@ -39,9 +39,9 @@ trait LogicalRewriter extends (LogicalOperator => LogicalOperator) {
   def rewriteChildren(child: LogicalOperator, r: LogicalRewriter = this): LogicalOperator = {
     child match {
       case b: BinaryLogicalOperator =>
-        b.withNewChildren(Seq(r(b.lhs), r(b.rhs)))
+        b.withNewChildren(Array(r(b.lhs), r(b.rhs)))
       case s: StackingLogicalOperator =>
-        s.withNewChildren(Seq(r(s.in)))
+        s.withNewChildren(Array(r(s.in)))
       case l: LogicalLeafOperator =>
         l
     }
@@ -73,8 +73,8 @@ object ExtractLabels extends LogicalAggregator[Set[(Var, Label)]] {
 case object DiscardStackedRecordOperations extends LogicalRewriter {
   override def apply(root: LogicalOperator): LogicalOperator = {
     root match {
-      case s: SetSourceGraph => s.withNewChildren(Seq(DiscardStackedRecordOperations(s.in)))
-      case p: ProjectGraph => p.withNewChildren(Seq(DiscardStackedRecordOperations(p.in)))
+      case s: SetSourceGraph => s.withNewChildren(Array(DiscardStackedRecordOperations(s.in)))
+      case p: ProjectGraph => p.withNewChildren(Array(DiscardStackedRecordOperations(p.in)))
       case s: StackingLogicalOperator => DiscardStackedRecordOperations(s.in)
       case other => rewriteChildren(other)
     }
@@ -92,7 +92,7 @@ case class PushLabelFiltersIntoScans(labelMap: Map[Var, Set[String]]) extends Lo
       case f@Filter(expr, in, _) =>
         expr match {
           case _: HasLabel => this (in)
-          case _ => f.withNewChildren(Seq(this(in)))
+          case _ => f.withNewChildren(Array(this(in)))
         }
       case other => rewriteChildren(other)
     }


### PR DESCRIPTION
Improve the tree node implementation by using array operations instead of Scala collections, both to improve the performance by a factor of 2-3, as well as to save stack frames, which allows to operate on trees that are several thousand nodes high. Using an array implementation (vs. Scala collection implementation) allows operations on trees that are around 5 times higher before risking a `StackOverflowException`.

NoOp rewrites: Add 28 NoOp nodes to a tree of height 8 with 55 nodes.
Simplify rewrite: Simplify all `Add`/`Number` expressions of that same tree into a single `Number` node.

Currently with Scala collection implementation:
```
Benchmark                               Mode  Cnt      Score      Error  Units
TreeNodeBenchmark.transformDownNoOp    thrpt   60  49032.580 ± 1150.623  ops/s
TreeNodeBenchmark.transformUpNoOp      thrpt   60  85578.855 ± 2720.386  ops/s
TreeNodeBenchmark.transformUpSimplify  thrpt   60  84564.706 ± 2848.754  ops/s
```

This PR with array implementation:
```
Benchmark                               Mode  Cnt       Score      Error  Units
TreeNodeBenchmark.transformDownNoOp    thrpt   60  156785.249 ± 2625.807  ops/s
TreeNodeBenchmark.transformUpNoOp      thrpt   60  199544.376 ± 2823.250  ops/s
TreeNodeBenchmark.transformUpSimplify  thrpt   60  274232.327 ± 9024.951  ops/s
```