### PR TITLE
Support lists of children in `AbstractTreeNode`

### DIFF
--- a/caps-core/src/main/scala/org/opencypher/caps/impl/common/TreeNode.scala
+++ b/caps-core/src/main/scala/org/opencypher/caps/impl/common/TreeNode.scala
@@ -114,9 +114,18 @@ abstract class TreeNode[T <: TreeNode[T]: ClassTag] extends Product with Travers
   /**
     * Arguments that should be printed. The default implementation excludes children.
     */
-  def args: Iterator[Any] = productIterator.flatMap {
-    case tn: T if containsChild(tn) => None // Don't print children
-    case other                      => Some(other)
+  def args: Iterator[Any] = {
+    def generalCase(arg: Any) = Some(arg.toString)
+    productIterator.flatMap {
+      case c: T if containsChild(c)     => None // Don't print children
+      case i: Iterable[_] if i.nonEmpty =>
+        // Need explicit pattern match for T, as `isInstanceOf` in `if` results in a warning.
+        i.head match {
+          case _: T => None // Don't print children
+          case _    => generalCase(i)
+        }
+      case other => generalCase(other)
+    }
   }
 
   override def toString = s"${getClass.getSimpleName}${if (argString.isEmpty) "" else s"($argString)"}"


### PR DESCRIPTION
This change allows to define tree nodes with a variable number of children like this:
```scala
abstract class CalcExpr extends AbstractTreeNode[CalcExpr]
case class Add(expressions: List[CalcExpr]) extends CalcExpr
case class Number(v: Int) extends CalcExpr

val calcExpr = Add(List(Number(1), Add(List(Number(2), Number(3), Number(4)))))
println(calcExpr.pretty)
```

This gets recognized and printed as:
```
|-Add
· |-Number(1)
· |-Add
· · |-Number(2)
· · |-Number(3)
· · |-Number(4)
```

