### PR TITLE
Add SQL interaction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ object Example extends App {
   */
 object SocialNetworkData {
 
-  case class Person(id: Long, name: String) extends schema.Node
+  case class Person(id: Long, name: String, age: Int) extends schema.Node
 
   @schema.RelationshipType("FRIEND_OF")
   case class Friend(id: Long, source: Long, target: Long, since: String) extends schema.Relationship
 
-  val alice = Person(0, "Alice")
-  val bob = Person(1, "Bob")
-  val carol = Person(2, "Carol")
+  val alice = Person(0, "Alice", 10)
+  val bob = Person(1, "Bob", 20)
+  val carol = Person(2, "Carol", 15)
 
   val persons = List(alice, bob, carol)
   val friendships = List(Friend(0, alice.id, bob.id, "23/01/1987"), Friend(1, bob.id, carol.id, "12/12/2009"))

--- a/caps-api/src/main/scala/org/opencypher/caps/api/graph/CypherSession.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/graph/CypherSession.scala
@@ -19,6 +19,7 @@ import java.net.URI
 
 import org.opencypher.caps.api.io.{CreateOrFail, PersistMode, PropertyGraphDataSource}
 import org.opencypher.caps.api.value.CypherValue._
+import org.opencypher.caps.impl.record.CypherRecords
 
 // TODO: extend doc with explanation for writing graphs
 /**
@@ -34,7 +35,7 @@ trait CypherSession {
     * @param parameters parameters used by the Cypher query
     * @return result of the query
     */
-  def cypher(query: String, parameters: CypherMap = CypherMap.empty): CypherResult
+  def cypher(query: String, parameters: CypherMap = CypherMap.empty, drivingTable: Option[CypherRecords] = None): CypherResult
 
   /**
     * Executes a Cypher query in this session, using the argument graph as the ambient graph.
@@ -47,7 +48,7 @@ trait CypherSession {
     * @param parameters parameters used by the Cypher query
     * @return result of the query
     */
-  private[graph] def cypherOnGraph(graph: PropertyGraph, query: String, parameters: CypherMap = CypherMap.empty): CypherResult
+  private[graph] def cypherOnGraph(graph: PropertyGraph, query: String, parameters: CypherMap = CypherMap.empty, drivingTable: Option[CypherRecords]): CypherResult
 
   /**
     * Reads a graph from the argument URI.

--- a/caps-api/src/main/scala/org/opencypher/caps/api/graph/PropertyGraph.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/graph/PropertyGraph.scala
@@ -75,8 +75,8 @@ trait PropertyGraph {
     * @return           the result of the query.
     * @see [[CypherSession.cypherOnGraph()]]
     */
-  final def cypher(query: String, parameters: CypherMap = CypherMap.empty): CypherResult =
-    session.cypherOnGraph(this, query, parameters)
+  final def cypher(query: String, parameters: CypherMap = CypherMap.empty, drivingTable: Option[CypherRecords] = None): CypherResult =
+    session.cypherOnGraph(this, query, parameters, drivingTable)
 
   /**
     * Constructs the union of this graph and the argument graph.

--- a/caps-api/src/main/scala/org/opencypher/caps/impl/record/CypherRecords.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/impl/record/CypherRecords.scala
@@ -80,4 +80,11 @@ trait CypherRecords extends CypherTable with CypherPrintable {
     * @return the number of records in this CypherRecords.
     */
   def size: Long
+
+  /**
+    * Registers these records as a table under the given name.
+    *
+    * @param name the name under which this table may be referenced.
+    */
+  def register(name: String): Unit
 }

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/fromFrontendType.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/fromFrontendType.scala
@@ -18,7 +18,6 @@ package org.opencypher.caps.ir.impl.typer
 import org.neo4j.cypher.internal.util.v3_4.{symbols => frontend}
 import org.opencypher.caps.api.types._
 
-// TODO: Should go to option I think
 case object fromFrontendType extends (frontend.CypherType => CypherType) {
   override def apply(in: frontend.CypherType): CypherType = in match {
     case frontend.CTAny           => CTAny
@@ -27,10 +26,11 @@ case object fromFrontendType extends (frontend.CypherType => CypherType) {
     case frontend.CTFloat         => CTFloat
     case frontend.CTBoolean       => CTBoolean
     case frontend.CTString        => CTString
-    case frontend.CTMap           => CTMap
     case frontend.CTNode          => CTNode
     case frontend.CTRelationship  => CTRelationship
+    case frontend.CTPath          => CTPath
+    case frontend.CTMap           => CTMap
     case frontend.ListType(inner) => CTList(fromFrontendType(inner))
-    case x                        => throw new UnsupportedOperationException(s"No support for type $x")
+    case x                        => throw new UnsupportedOperationException(s"Can not convert openCypher frontend type $x to a CAPS type")
   }
 }

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/toFrontendType.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/toFrontendType.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.caps.ir.impl.typer
+
+import org.neo4j.cypher.internal.util.v3_4.{symbols => frontend}
+import org.opencypher.caps.api.types._
+
+case object toFrontendType extends (CypherType => frontend.CypherType) {
+  override def apply(in: CypherType): frontend.CypherType = in.material match {
+    case CTAny          => frontend.CTAny
+    case CTNumber       => frontend.CTNumber
+    case CTInteger      => frontend.CTInteger
+    case CTFloat        => frontend.CTFloat
+    case CTBoolean      => frontend.CTBoolean
+    case CTString       => frontend.CTString
+    case CTNode         => frontend.CTNode
+    case CTRelationship => frontend.CTRelationship
+    case CTPath         => frontend.CTPath
+    case CTMap          => frontend.CTMap
+    case CTList(inner)  => frontend.ListType(toFrontendType(inner))
+    case x => throw new UnsupportedOperationException(s"Can not convert CAPS type $x to an openCypher frontend type")
+  }
+}

--- a/caps-ir/src/test/scala/org/opencypher/caps/ir/impl/typer/fromFrontendTypeTest.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/ir/impl/typer/fromFrontendTypeTest.scala
@@ -16,15 +16,35 @@
 package org.opencypher.caps.ir.impl.typer
 
 import org.neo4j.cypher.internal.util.v3_4.{symbols => frontend}
-import org.opencypher.caps.api.types.{CTBoolean, CTFloat, CTInteger, CTNumber}
+import org.opencypher.caps.api.types._
 import org.opencypher.caps.test.BaseTestSuite
+import org.scalatest.Assertion
 
 class fromFrontendTypeTest extends BaseTestSuite {
 
   test("should convert basic types") {
-    fromFrontendType(frontend.CTBoolean) shouldBe CTBoolean
-    fromFrontendType(frontend.CTInteger) shouldBe CTInteger
-    fromFrontendType(frontend.CTFloat) shouldBe CTFloat
-    fromFrontendType(frontend.CTNumber) shouldBe CTNumber
+    frontend.CTBoolean shouldBeConvertedTo CTBoolean
+    frontend.CTInteger shouldBeConvertedTo CTInteger
+    frontend.CTFloat shouldBeConvertedTo CTFloat
+    frontend.CTNumber shouldBeConvertedTo CTNumber
+    frontend.CTString shouldBeConvertedTo CTString
+    frontend.CTAny shouldBeConvertedTo CTAny
+  }
+
+  test("should convert entity types") {
+    frontend.CTNode shouldBeConvertedTo CTNode
+    frontend.CTRelationship shouldBeConvertedTo CTRelationship
+    frontend.CTPath shouldBeConvertedTo CTPath
+  }
+
+  test("should convert container types") {
+    frontend.CTList(frontend.CTInteger) shouldBeConvertedTo CTList(CTInteger)
+    frontend.CTMap shouldBeConvertedTo CTMap
+  }
+
+  implicit class RichType(t: frontend.CypherType) {
+    def shouldBeConvertedTo(other: CypherType): Assertion = {
+      fromFrontendType(t) should equal(other)
+    }
   }
 }

--- a/caps-ir/src/test/scala/org/opencypher/caps/ir/impl/typer/toFrontendTypeTest.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/ir/impl/typer/toFrontendTypeTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.caps.ir.impl.typer
+
+import org.neo4j.cypher.internal.util.v3_4.{symbols => frontend}
+import org.opencypher.caps.api.types._
+import org.opencypher.caps.test.BaseTestSuite
+import org.scalatest.Assertion
+
+class toFrontendTypeTest extends BaseTestSuite {
+
+  it("can convert basic types") {
+    CTAny shouldBeConvertedTo frontend.CTAny
+    CTAny.nullable shouldBeConvertedTo frontend.CTAny
+    CTInteger shouldBeConvertedTo frontend.CTInteger
+    CTInteger.nullable shouldBeConvertedTo frontend.CTInteger
+    CTFloat shouldBeConvertedTo frontend.CTFloat
+    CTFloat.nullable shouldBeConvertedTo frontend.CTFloat
+    CTNumber shouldBeConvertedTo frontend.CTNumber
+    CTNumber.nullable shouldBeConvertedTo frontend.CTNumber
+    CTBoolean shouldBeConvertedTo frontend.CTBoolean
+    CTBoolean.nullable shouldBeConvertedTo frontend.CTBoolean
+    CTString shouldBeConvertedTo frontend.CTString
+    CTString.nullable shouldBeConvertedTo frontend.CTString
+  }
+
+  test("should convert entity types") {
+    CTNode shouldBeConvertedTo frontend.CTNode
+    CTNode.nullable shouldBeConvertedTo frontend.CTNode
+    CTRelationship shouldBeConvertedTo frontend.CTRelationship
+    CTRelationship.nullable shouldBeConvertedTo frontend.CTRelationship
+    CTPath shouldBeConvertedTo frontend.CTPath
+  }
+
+  test("should convert container types") {
+    CTList(CTInteger) shouldBeConvertedTo frontend.CTList(frontend.CTInteger)
+    CTList(CTInteger).nullable shouldBeConvertedTo frontend.CTList(frontend.CTInteger)
+    CTList(CTInteger.nullable) shouldBeConvertedTo frontend.CTList(frontend.CTInteger)
+    CTMap shouldBeConvertedTo frontend.CTMap
+    CTMap.nullable shouldBeConvertedTo frontend.CTMap
+  }
+
+  implicit class RichType(t: CypherType) {
+    def shouldBeConvertedTo(other: frontend.CypherType): Assertion = {
+      toFrontendType(t) should equal(other)
+    }
+  }
+}

--- a/caps-spark/src/main/scala/org/opencypher/caps/api/CAPSSession.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/api/CAPSSession.scala
@@ -34,8 +34,7 @@ import scala.reflect.runtime.universe._
 
 trait CAPSSession extends CypherSession {
 
-  def sql(query: String): CypherRecords =
-    CAPSRecords.wrap(sparkSession.sql(query))(this)
+  def sql(query: String): CypherRecords
 
   def sparkSession: SparkSession
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/api/CAPSSession.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/api/CAPSSession.scala
@@ -25,6 +25,7 @@ import org.opencypher.caps.api.graph.{CypherSession, PropertyGraph}
 import org.opencypher.caps.api.schema.EntityTable.SparkTable
 import org.opencypher.caps.api.schema._
 import org.opencypher.caps.demo.CypherKryoRegistrar
+import org.opencypher.caps.impl.record.CypherRecords
 import org.opencypher.caps.impl.spark._
 import org.opencypher.caps.impl.spark.io.{CAPSGraphSourceHandler, CAPSPropertyGraphDataSourceFactory}
 
@@ -32,6 +33,9 @@ import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe._
 
 trait CAPSSession extends CypherSession {
+
+  def sql(query: String): CypherRecords =
+    CAPSRecords.wrap(sparkSession.sql(query))(this)
 
   def sparkSession: SparkSession
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
@@ -353,7 +353,7 @@ object CAPSRecords {
     * @param caps the session to which the resulting CAPSRecords is tied.
     * @return a Cypher table.
     */
-  def wrap(df: DataFrame)(implicit caps: CAPSSession): CAPSRecords =
+  private[spark] def wrap(df: DataFrame)(implicit caps: CAPSSession): CAPSRecords =
     verifyAndCreate(prepareDataFrame(df))
 
   /**
@@ -371,6 +371,9 @@ object CAPSRecords {
     (initialHeader, withRenamedColumns)
   }
 
+  /**
+    * Normalises the dataframe by lifting numeric fields to Long and similar ops.
+    */
   private def generalizeColumnTypes(initialDataFrame: DataFrame): DataFrame = {
     val toCast = initialDataFrame.schema.fields.filter(f => fromSparkType(f.dataType, f.nullable).isEmpty)
     val dfWithCompatibleTypes: DataFrame = toCast.foldLeft(initialDataFrame) {

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
@@ -51,6 +51,9 @@ sealed abstract class CAPSRecords(override val header: RecordHeader, val data: D
   override def print(implicit options: PrintOptions): Unit =
     RecordsPrinter.print(this)
 
+  override def register(name: String): Unit =
+    data.createOrReplaceTempView(name)
+
   override def size: Long = data.count()
 
   def sparkColumns: IndexedSeq[String] = header.internalHeader.columns

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
@@ -344,6 +344,16 @@ object CAPSRecords {
   }
 
   /**
+    * Wraps a Spark SQL table (DataFrame) in a CAPSRecords, making it understandable by Cypher.
+    *
+    * @param df the table to wrap.
+    * @param caps the session to which the resulting CAPSRecords is tied.
+    * @return a Cypher table.
+    */
+  def wrap(df: DataFrame)(implicit caps: CAPSSession): CAPSRecords =
+    verifyAndCreate(prepareDataFrame(df))
+
+  /**
     * Validates the data types within the DataFrame for compatibility, creates an initial [[RecordHeader]] and aligns
     * the data frame column names according to that header.
     *

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSSessionImpl.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSSessionImpl.scala
@@ -86,10 +86,10 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession, private val graphSo
   def unmountAll(): Unit =
     graphSourceHandler.unmountAll(this)
 
-  override def cypher(query: String, parameters: CypherMap): CypherResult =
-    cypherOnGraph(CAPSGraph.empty(this), query, parameters)
+  override def cypher(query: String, parameters: CypherMap, drivingTable: Option[CypherRecords]): CypherResult =
+    cypherOnGraph(CAPSGraph.empty(this), query, parameters, drivingTable)
 
-  override def cypherOnGraph(graph: PropertyGraph, query: String, queryParameters: CypherMap): CypherResult = {
+  override def cypherOnGraph(graph: PropertyGraph, query: String, queryParameters: CypherMap, maybeDrivingTable: Option[CypherRecords]): CypherResult = {
     val ambientGraph = mountAmbientGraph(graph)
 
     val (stmt, extractedLiterals, semState) = parser.process(query)(CypherParser.defaultContext)

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSSessionImpl.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSSessionImpl.scala
@@ -86,6 +86,9 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession, private val graphSo
   def unmountAll(): Unit =
     graphSourceHandler.unmountAll(this)
 
+  override def sql(query: String): CAPSRecords =
+    CAPSRecords.wrap(sparkSession.sql(query))(this)
+
   override def cypher(query: String, parameters: CypherMap, drivingTable: Option[CypherRecords]): CypherResult =
     cypherOnGraph(CAPSGraph.empty(this), query, parameters, drivingTable)
 

--- a/caps-spark/src/test/scala/org/opencypher/caps/demo/CypherSQLRoundtripExample.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/demo/CypherSQLRoundtripExample.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.caps.demo
+
+import org.opencypher.caps.api.{CAPSSession, schema}
+import org.opencypher.caps.impl.record.CypherRecords
+
+/**
+  * Demonstrates usage patterns where Cypher and SQL can be interleaved in the
+  * same processing chain, by using the tabular output of a Cypher query as a
+  * SQL table, and using the output of a SQL query as an input driving table
+  * for a Cypher query.
+  */
+object CypherSQLRoundtripExample extends App {
+  // 1) Create CAPS session
+  implicit val session = CAPSSession.local()
+
+  // 2) Load social network data via case class instances
+  val socialNetwork = session.readFrom(SampleData.persons, SampleData.friendships)
+
+  // 3) Query for a view of the people in the social network
+  val result = socialNetwork.cypher(
+    """|MATCH (p:Person)
+       |RETURN p.age AS age, p.name AS name
+    """.stripMargin
+  )
+
+  // 4) Register the result as a table called people
+  result.records.register("people")
+
+  // 5) Query the registered table using SQL
+  val sqlResults: CypherRecords = session.sql("SELECT age, name FROM people")
+
+  sqlResults.print
+
+  // 6) Load a purchase network graph via CSV + Schema files
+//  val csvFolder = getClass.getResource("/csv/prod/").getFile
+//  val purchaseNetwork = session.readFrom(s"file+csv://$csvFolder")
+
+  // 7) Use the results from the SQL query as driving table for a Cypher query
+//  val result2 = purchaseNetwork.cypher("MATCH (c:Customer {name: name})-->(p:Product) RETURN c.name, age, p.title")//,
+//    drivingTable = Some(sqlRecords))
+
+//  result2.print
+
+}
+
+/**
+  * Specify schema and data with case classes.
+  */
+object SampleData {
+
+  case class Person(id: Long, name: String, age: Int) extends schema.Node
+
+  @schema.RelationshipType("FRIEND_OF")
+  case class Friend(id: Long, source: Long, target: Long, since: String) extends schema.Relationship
+
+  val alice = Person(0, "Alice", 10)
+  val bob = Person(1, "Bob", 15)
+  val carol = Person(2, "Carol", 25)
+
+  val persons = List(alice, bob, carol)
+  val friendships = List(Friend(0, alice.id, bob.id, "23/01/1987"), Friend(1, bob.id, carol.id, "12/12/2009"))
+}

--- a/caps-spark/src/test/scala/org/opencypher/caps/demo/CypherSQLRoundtripExample.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/demo/CypherSQLRoundtripExample.scala
@@ -44,18 +44,16 @@ object CypherSQLRoundtripExample extends App {
   // 5) Query the registered table using SQL
   val sqlResults: CypherRecords = session.sql("SELECT age, name FROM people")
 
-  sqlResults.print
+//  sqlResults.print
 
   // 6) Load a purchase network graph via CSV + Schema files
-//  val csvFolder = getClass.getResource("/csv/prod/").getFile
-//  val purchaseNetwork = session.readFrom(s"file+csv://$csvFolder")
+  val csvFolder = getClass.getResource("/csv/prod/").getFile
+  val purchaseNetwork = session.readFrom(s"file+csv://$csvFolder")
 
   // 7) Use the results from the SQL query as driving table for a Cypher query
-//  val result2 = purchaseNetwork.cypher("MATCH (c:Customer {name: name})-->(p:Product) RETURN c.name, age, p.title")//,
-//    drivingTable = Some(sqlRecords))
+  val result2 = purchaseNetwork.cypher("WITH name AS name, age AS age MATCH (c:Customer {name: name})-->(p:Product) RETURN c.name, age, p.title", drivingTable = Some(sqlResults))
 
-//  result2.print
-
+  result2.print
 }
 
 /**

--- a/caps-spark/src/test/scala/org/opencypher/caps/demo/CypherSQLRoundtripExample.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/demo/CypherSQLRoundtripExample.scala
@@ -29,7 +29,7 @@ object CypherSQLRoundtripExample extends App {
   implicit val session = CAPSSession.local()
 
   // 2) Load social network data via case class instances
-  val socialNetwork = session.readFrom(SampleData.persons, SampleData.friendships)
+  val socialNetwork = session.readFrom(SocialNetworkData.persons, SocialNetworkData.friendships)
 
   // 3) Query for a view of the people in the social network
   val result = socialNetwork.cypher(
@@ -54,22 +54,4 @@ object CypherSQLRoundtripExample extends App {
   val result2 = purchaseNetwork.cypher("WITH name AS name, age AS age MATCH (c:Customer {name: name})-->(p:Product) RETURN c.name, age, p.title", drivingTable = Some(sqlResults))
 
   result2.print
-}
-
-/**
-  * Specify schema and data with case classes.
-  */
-object SampleData {
-
-  case class Person(id: Long, name: String, age: Int) extends schema.Node
-
-  @schema.RelationshipType("FRIEND_OF")
-  case class Friend(id: Long, source: Long, target: Long, since: String) extends schema.Relationship
-
-  val alice = Person(0, "Alice", 10)
-  val bob = Person(1, "Bob", 15)
-  val carol = Person(2, "Carol", 25)
-
-  val persons = List(alice, bob, carol)
-  val friendships = List(Friend(0, alice.id, bob.id, "23/01/1987"), Friend(1, bob.id, carol.id, "12/12/2009"))
 }

--- a/caps-spark/src/test/scala/org/opencypher/caps/demo/Example.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/demo/Example.scala
@@ -43,14 +43,14 @@ object Example extends App {
   */
 object SocialNetworkData {
 
-  case class Person(id: Long, name: String) extends schema.Node
+  case class Person(id: Long, name: String, age: Int) extends schema.Node
 
   @schema.RelationshipType("FRIEND_OF")
   case class Friend(id: Long, source: Long, target: Long, since: String) extends schema.Relationship
 
-  val alice = Person(0, "Alice")
-  val bob = Person(1, "Bob")
-  val carol = Person(2, "Carol")
+  val alice = Person(0, "Alice", 10)
+  val bob = Person(1, "Bob", 20)
+  val carol = Person(2, "Carol", 15)
 
   val persons = List(alice, bob, carol)
   val friendships = List(Friend(0, alice.id, bob.id, "23/01/1987"), Friend(1, bob.id, carol.id, "12/12/2009"))

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/record/EntityTableTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/record/EntityTableTest.scala
@@ -42,7 +42,8 @@ class EntityTableTest extends CAPSTestSuite {
     personTableScala.mapping should equal(NodeMapping
       .withSourceIdKey("id")
       .withImpliedLabel("Person")
-      .withPropertyKey("name"))
+      .withPropertyKey("name")
+      .withPropertyKey("age"))
 
     val friends = List(Friend(0, 0, 1, "23/01/1987"), Friend(1, 1, 2, "12/12/2009"))
     val friendTableScala = CAPSRelationshipTable(friends)

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/record/EntityTableTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/record/EntityTableTest.scala
@@ -38,7 +38,7 @@ class EntityTableTest extends CAPSTestSuite {
     .withPropertyKey("bar" -> "BAR")
 
   test("mapping from scala classes") {
-    val personTableScala = CAPSNodeTable(List(Person(0, "Alice")))
+    val personTableScala = CAPSNodeTable(List(Person(0, "Alice", 15)))
     personTableScala.mapping should equal(NodeMapping
       .withSourceIdKey("id")
       .withImpliedLabel("Person")

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
@@ -32,6 +32,24 @@ import scala.collection.Bag
 
 class CAPSRecordsTest extends CAPSTestSuite with GraphCreationFixture {
 
+  it("can wrap a dataframe") {
+    val givenDF = session.createDataFrame(
+      Seq(
+        (1L, true, "Mats"),
+        (2L, false, "Martin"),
+        (3L, false, "Max"),
+        (4L, false, "Stefan")
+      )).toDF("ID", "IS_SWEDE", "NAME")
+
+    val records = CAPSRecords.wrap(givenDF)
+
+    records.header.slots.map(s => s.content -> s.content.cypherType).toSet should equal(Set(
+      OpaqueField(Var("ID")()) -> CTInteger,
+      OpaqueField(Var("IS_SWEDE")()) -> CTBoolean,
+      OpaqueField(Var("NAME")()) -> CTString.nullable
+    ))
+  }
+
   test("verify CAPSRecords header") {
     val givenDF = session.createDataFrame(
           Seq(

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
@@ -50,6 +50,27 @@ class CAPSRecordsTest extends CAPSTestSuite with GraphCreationFixture {
     ))
   }
 
+  it("can be registered and queried from SQL") {
+    val givenDF = session.createDataFrame(
+      Seq(
+        (1L, true, "Mats"),
+        (2L, false, "Martin"),
+        (3L, false, "Max"),
+        (4L, false, "Stefan")
+      )).toDF("ID", "IS_SWEDE", "NAME")
+
+    CAPSRecords.wrap(givenDF).register("people")
+
+    val df = session.sql("SELECT * FROM people")
+
+    df.collect() should equal(Array(
+      Row(1L, true, "Mats"),
+      Row(2L, false, "Martin"),
+      Row(3L, false, "Max"),
+      Row(4L, false, "Stefan")
+    ))
+  }
+
   test("verify CAPSRecords header") {
     val givenDF = session.createDataFrame(
           Seq(

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSSessionImplTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSSessionImplTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.caps.impl.spark
+
+import org.opencypher.caps.api.value.CypherValue.CypherMap
+import org.opencypher.caps.test.CAPSTestSuite
+import org.opencypher.caps.test.fixture.TeamDataFixture
+
+import scala.collection.Bag
+
+class CAPSSessionImplTest extends CAPSTestSuite with TeamDataFixture {
+
+  it("can execute sql on registered tables") {
+    CAPSRecords.wrap(personDF).register("people")
+    CAPSRecords.wrap(knowsDF).register("knows")
+
+    val sqlResult = caps.sql(
+      """
+        |SELECT people.name AS me, knows.since AS since, p2.name AS you
+        |FROM people
+        |INNER JOIN knows ON knows.src = people.id
+        |INNER JOIN people p2 ON knows.dst = p2.id
+      """.stripMargin)
+
+    sqlResult.iterator.toBag should equal(Bag(
+      CypherMap("me" -> "Mats", "since" -> 2017, "you" -> "Martin"),
+      CypherMap("me" -> "Mats", "since" -> 2016, "you" -> "Max"),
+      CypherMap("me" -> "Mats", "since" -> 2015, "you" -> "Stefan"),
+      CypherMap("me" -> "Martin", "since" -> 2016, "you" -> "Max"),
+      CypherMap("me" -> "Martin", "since" -> 2013, "you" -> "Stefan"),
+      CypherMap("me" -> "Max", "since" -> 2016, "you" -> "Stefan")
+    ))
+  }
+
+}

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/MatchBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/MatchBehaviour.scala
@@ -17,6 +17,7 @@ package org.opencypher.caps.impl.spark.acceptance
 
 import org.opencypher.caps.api.value.CypherValue._
 import org.opencypher.caps.impl.spark.CAPSGraph
+import org.opencypher.caps.logical.api.configuration.LogicalConfiguration.PrintLogicalPlan
 
 import scala.collection.Bag
 

--- a/caps-spark/src/test/scala/org/opencypher/caps/test/fixture/TeamDataFixture.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/test/fixture/TeamDataFixture.scala
@@ -61,7 +61,7 @@ trait TeamDataFixture extends TestDataFixture with DebugOutputSupport {
     .withPropertyKey("name" -> "NAME")
     .withPropertyKey("luckyNumber" -> "NUM")
 
-  private lazy val personDF: DataFrame = caps.sparkSession.createDataFrame(
+  protected lazy val personDF: DataFrame = caps.sparkSession.createDataFrame(
     Seq(
       (1L, true, "Mats", 23L),
       (2L, false, "Martin", 42L),
@@ -75,7 +75,7 @@ trait TeamDataFixture extends TestDataFixture with DebugOutputSupport {
     .on("ID").from("SRC").to("DST").relType("KNOWS").withPropertyKey("since" -> "SINCE")
 
 
-  private lazy val knowsDF: DataFrame = caps.sparkSession.createDataFrame(
+  protected lazy val knowsDF: DataFrame = caps.sparkSession.createDataFrame(
     Seq(
       (1L, 1L, 2L, 2017L),
       (1L, 2L, 3L, 2016L),


### PR DESCRIPTION
This enables the tabular result of a Cypher query to be registered as a named table in the session, and adds a SQL query call to `CAPSSession` which may refer to such registered tables.