### PR TITLE
TCK compatible exceptions

### DIFF
--- a/caps-api/src/main/scala/org/opencypher/caps/api/exception/CypherException.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/exception/CypherException.scala
@@ -15,17 +15,106 @@
  */
 package org.opencypher.caps.api.exception
 
-abstract class CypherException(msg: String) extends RuntimeException(msg) with Serializable
+import org.opencypher.caps.api.exception.CypherException.{ErrorDetails, ErrorPhase, ErrorType}
 
-final case class SchemaException(msg: String) extends CypherException(msg)
+/**
+  * Cypher exceptions are thrown due to the reasons specified by the Cypher TCK and follow the specified format.
+  */
+abstract class CypherException(errorType: ErrorType, phase: ErrorPhase, detail: ErrorDetails) extends RuntimeException(s"$errorType during $phase. Details: $detail") with Serializable
 
-final case class CypherValueException(msg: String) extends CypherException(msg)
+object CypherException {
 
-final case class NotImplementedException(msg: String) extends CypherException(msg)
+  sealed trait ErrorType
 
-final case class IllegalStateException(msg: String) extends CypherException(msg)
+  /**
+    * Possible error types as specified by the TCK.
+    */
+  object ErrorType {
 
-final case class IllegalArgumentException(expected: Any, actual: Any = "none")
-  extends CypherException(s"\nExpected:\n\t$expected\nFound:\n\t$actual")
+    object SyntaxError extends ErrorType
 
-final case class UnsupportedOperationException(msg: String) extends CypherException(msg)
+    object ParameterMissing extends ErrorType
+
+    object ConstraintVerificationFailed extends ErrorType
+
+    //TODO: Validation/verification are too similar. Fix in TCK?
+    object ConstraintValidationFailed extends ErrorType
+
+    object EntityNotFound extends ErrorType
+
+    object PropertyNotFound extends ErrorType
+
+    object LabelNotFound extends ErrorType
+
+    object TypeError extends ErrorType
+
+    object ArgumentError extends ErrorType
+
+    object ArithmeticError extends ErrorType
+
+    object ProcedureError extends ErrorType
+
+  }
+
+  sealed trait ErrorPhase
+
+  /**
+    * Possible error phases as specified by the TCK.
+    */
+  object ErrorPhase {
+
+    object Runtime extends ErrorPhase
+
+    object CompileTime extends ErrorPhase
+
+  }
+
+  sealed trait ErrorDetails
+
+  /**
+    * Possible error details as specified by the TCK.
+    */
+  object ErrorDetails {
+    object InvalidElementAccess extends ErrorDetails
+    object MapElementAccessByNonString extends ErrorDetails
+    object ListElementAccessByNonInteger extends ErrorDetails
+    object NestedAggregation extends ErrorDetails
+    object NegativeIntegerArgument extends ErrorDetails
+    object DeleteConnectedNode extends ErrorDetails
+    object RequiresDirectedRelationship extends ErrorDetails
+    object InvalidRelationshipPattern extends ErrorDetails
+    object VariableAlreadyBound extends ErrorDetails
+    object InvalidArgumentType extends ErrorDetails
+    object InvalidArgumentValue extends ErrorDetails
+    object NumberOutOfRange extends ErrorDetails
+    object UndefinedVariable extends ErrorDetails
+    object VariableTypeConflict extends ErrorDetails
+    object RelationshipUniquenessViolation extends ErrorDetails
+    object CreatingVarLength extends ErrorDetails
+    object InvalidParameterUse extends ErrorDetails
+    object InvalidClauseComposition extends ErrorDetails
+    object FloatingPointOverflow extends ErrorDetails
+    object PropertyAccessOnNonMap extends ErrorDetails
+    object InvalidArgumentExpression extends ErrorDetails
+    object InvalidUnicodeCharacter extends ErrorDetails
+    object NonConstantExpression extends ErrorDetails
+    object NoSingleRelationshipType extends ErrorDetails
+    object InvalidAggregation extends ErrorDetails
+    object UnknownFunction extends ErrorDetails
+    object InvalidNumberLiteral extends ErrorDetails
+    object InvalidUnicodeLiteral extends ErrorDetails
+    object MergeReadOwnWrites extends ErrorDetails
+    object NoExpressionAlias extends ErrorDetails
+    object DifferentColumnsInUnion extends ErrorDetails
+    object InvalidDelete extends ErrorDetails
+    object InvalidPropertyType extends ErrorDetails
+    object ColumnNameConflict extends ErrorDetails
+    object NoVariablesInScope extends ErrorDetails
+    object DeletedEntityAccess extends ErrorDetails
+    object InvalidArgumentPassingMode extends ErrorDetails
+    object InvalidNumberOfArguments extends ErrorDetails
+    object MissingParameter extends ErrorDetails
+    object ProcedureNotFound extends ErrorDetails
+  }
+
+}

--- a/caps-api/src/main/scala/org/opencypher/caps/api/io/conversion/EntityMapping.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/io/conversion/EntityMapping.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.api.io.conversion
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types.{CypherType, DefiniteCypherType}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 
 /**
   * Represents a map from node property keys to keys in the source data.

--- a/caps-api/src/main/scala/org/opencypher/caps/api/io/conversion/NodeMapping.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/io/conversion/NodeMapping.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.api.io.conversion
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types.CTNode
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 
 object NodeMapping {
   /**

--- a/caps-api/src/main/scala/org/opencypher/caps/api/io/conversion/RelationshipMapping.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/io/conversion/RelationshipMapping.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.api.io.conversion
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types.CTRelationship
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 
 object RelationshipMapping {
   /**

--- a/caps-api/src/main/scala/org/opencypher/caps/api/schema/Schema.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/schema/Schema.scala
@@ -15,9 +15,9 @@
  */
 package org.opencypher.caps.api.schema
 
-import org.opencypher.caps.api.exception.SchemaException
 import org.opencypher.caps.api.schema.PropertyKeys.PropertyKeys
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.SchemaException
 
 import scala.language.{existentials, implicitConversions} // fix compiler warning
 

--- a/caps-api/src/main/scala/org/opencypher/caps/api/value/CypherValue.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/value/CypherValue.scala
@@ -17,7 +17,8 @@ package org.opencypher.caps.api.value
 
 import java.util.Objects
 
-import org.opencypher.caps.api.exception._
+import org.opencypher.caps.impl.exception._
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 
 import scala.reflect.{ClassTag, classTag}
 import scala.util.Try

--- a/caps-api/src/main/scala/org/opencypher/caps/impl/exception/InternalException.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/impl/exception/InternalException.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.caps.impl.exception
+
+/**
+  * Exceptions that are not covered by the TCK. They are related to limitations of a specific Cypher implementation
+  * or to session or property graph interactions that are not covered by the TCK.
+  */
+//TODO: Either: 1. Convert to CypherException; 2. Create categories that makes sense in the API module for them; or 3. Move to the internals of the system to which they belong.
+abstract class InternalException(msg: String) extends RuntimeException(msg) with Serializable
+
+final case class SchemaException(msg: String) extends InternalException(msg)
+
+final case class CypherValueException(msg: String) extends InternalException(msg)
+
+final case class NotImplementedException(msg: String) extends InternalException(msg)
+
+final case class IllegalStateException(msg: String) extends InternalException(msg)
+
+final case class IllegalArgumentException(expected: Any, actual: Any = "none")
+  extends InternalException(s"\nExpected:\n\t$expected\nFound:\n\t$actual")
+
+final case class UnsupportedOperationException(msg: String) extends InternalException(msg)

--- a/caps-api/src/test/scala/org/opencypher/caps/api/io/conversion/EntityMappingTest.scala
+++ b/caps-api/src/test/scala/org/opencypher/caps/api/io/conversion/EntityMappingTest.scala
@@ -15,7 +15,7 @@
  */
 package org.opencypher.caps.api.io.conversion
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.test.BaseTestSuite
 
 class EntityMappingTest extends BaseTestSuite {

--- a/caps-api/src/test/scala/org/opencypher/caps/api/schema/SchemaTest.scala
+++ b/caps-api/src/test/scala/org/opencypher/caps/api/schema/SchemaTest.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.api.schema
 
-import org.opencypher.caps.api.exception.SchemaException
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.SchemaException
 import org.opencypher.caps.test.BaseTestSuite
 
 class SchemaTest extends BaseTestSuite {

--- a/caps-cora/src/main/scala/org/opencypher/caps/impl/exception/CoraException.scala
+++ b/caps-cora/src/main/scala/org/opencypher/caps/impl/exception/CoraException.scala
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opencypher.caps.ir.api.exception
+package org.opencypher.caps.impl.exception
 
-import org.opencypher.caps.api.exception.CypherException
+import org.opencypher.caps.ir.api.expr.Var
 
-abstract class IrException(msg: String) extends CypherException(msg)
+abstract class CoraException(msg: String) extends InternalException(msg)
 
-final case class PatternConversionException(msg: String) extends IrException(msg)
+final case class RecordHeaderException(msg: String) extends CoraException(msg)
 
-final case class TyperException(msg: String) extends IrException(msg)
-
-final case class ParsingException(msg: String) extends IrException(msg)
+final case class DuplicateSourceColumnException(columnName: String, entity: Var)
+    extends CoraException(
+          s"The source column '$columnName' is used more than once to describe the mapping of $entity")

--- a/caps-cora/src/main/scala/org/opencypher/caps/impl/flat/FlatOperatorProducer.scala
+++ b/caps-cora/src/main/scala/org/opencypher/caps/impl/flat/FlatOperatorProducer.scala
@@ -16,9 +16,10 @@
 package org.opencypher.caps.impl.flat
 
 import cats.Monoid
-import org.opencypher.caps.api.exception.{IllegalStateException, RecordHeaderException}
+import org.opencypher.caps.impl.exception.RecordHeaderException
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.IllegalStateException
 import org.opencypher.caps.impl.record._
 import org.opencypher.caps.impl.syntax.RecordHeaderSyntax._
 import org.opencypher.caps.ir.api.block.SortItem

--- a/caps-cora/src/main/scala/org/opencypher/caps/impl/flat/FlatPlanner.scala
+++ b/caps-cora/src/main/scala/org/opencypher/caps/impl/flat/FlatPlanner.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.impl.flat
 
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.value.CypherValue._
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.impl.record.{ProjectedExpr, ProjectedField}
 import org.opencypher.caps.ir.api.util.DirectCompilationStage
 import org.opencypher.caps.logical.impl.LogicalOperator

--- a/caps-cora/src/main/scala/org/opencypher/caps/impl/physical/PhysicalPlanner.scala
+++ b/caps-cora/src/main/scala/org/opencypher/caps/impl/physical/PhysicalPlanner.scala
@@ -15,10 +15,11 @@
  */
 package org.opencypher.caps.impl.physical
 
-import org.opencypher.caps.api.exception.{IllegalArgumentException, NotImplementedException}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.{CypherSession, PropertyGraph}
 import org.opencypher.caps.api.physical.{PhysicalOperator, PhysicalOperatorProducer, PhysicalPlannerContext, RuntimeContext}
 import org.opencypher.caps.api.types.CTRelationship
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, NotImplementedException}
 import org.opencypher.caps.impl.flat
 import org.opencypher.caps.impl.flat.FlatOperator
 import org.opencypher.caps.impl.record.CypherRecords

--- a/caps-cora/src/main/scala/org/opencypher/caps/impl/record/RecordHeader.scala
+++ b/caps-cora/src/main/scala/org/opencypher/caps/impl/record/RecordHeader.scala
@@ -15,9 +15,9 @@
  */
 package org.opencypher.caps.impl.record
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types.{CTBoolean, CTNode, CTString, _}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.syntax.RecordHeaderSyntax._
 import org.opencypher.caps.ir.api.expr._
 import org.opencypher.caps.ir.api.{Label, PropertyKey}

--- a/caps-cora/src/main/scala/org/opencypher/caps/impl/record/SlotContent.scala
+++ b/caps-cora/src/main/scala/org/opencypher/caps/impl/record/SlotContent.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.impl.record
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.ir.api.expr._
 
 final case class RecordSlot(index: Int, content: SlotContent) {

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCConverters.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCConverters.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.cosc.impl
 
-import org.opencypher.caps.api.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.{CypherResult, CypherSession, PropertyGraph}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.impl.record.{CypherRecordHeader, CypherRecords, RecordHeader}
 
 object COSCConverters {

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCRecords.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCRecords.scala
@@ -55,6 +55,13 @@ sealed abstract class COSCRecords(
   override def size: Long = rows.size
 
   override def print(implicit options: PrintOptions): Unit = RecordsPrinter.print(this)
+
+  /**
+    * Registers these records as a table under the given name.
+    *
+    * @param name the name under which this table may be referenced.
+    */
+  override def register(name: String): Unit = ???
 }
 
 

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCSession.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCSession.scala
@@ -30,6 +30,7 @@ import org.opencypher.caps.cosc.impl.planning.{COSCPhysicalOperatorProducer, COS
 import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.impl.flat.{FlatPlanner, FlatPlannerContext}
 import org.opencypher.caps.impl.physical.PhysicalPlanner
+import org.opencypher.caps.impl.record.CypherRecords
 import org.opencypher.caps.impl.util.Measurement.time
 import org.opencypher.caps.ir.api.IRExternalGraph
 import org.opencypher.caps.ir.impl.parse.CypherParser
@@ -68,10 +69,10 @@ class COSCSession(private val graphSourceHandler: COSCGraphSourceHandler) extend
     * @param parameters parameters used by the Cypher query
     * @return result of the query
     */
-  override def cypher(query: String, parameters: CypherMap): CypherResult =
-    cypherOnGraph(COSCGraph.empty(this), query, parameters)
+  override def cypher(query: String, parameters: CypherMap = CypherMap.empty, drivingTable: Option[CypherRecords] = None): CypherResult =
+    cypherOnGraph(COSCGraph.empty(this), query, parameters, drivingTable)
 
-  override def cypherOnGraph(graph: PropertyGraph, query: String, parameters: CypherMap): CypherResult = {
+  override def cypherOnGraph(graph: PropertyGraph, query: String, parameters: CypherMap, drivingTable: Option[CypherRecords]): CypherResult = {
     val ambientGraph = getAmbientGraph(graph)
 
     val (stmt, extractedLiterals, semState) = time("AST construction")(parser.process(query)(CypherParser.defaultContext))

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCSession.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCSession.scala
@@ -19,7 +19,6 @@ import java.net.URI
 import java.util.UUID
 
 import org.opencypher.caps.api.configuration.CoraConfiguration.PrintFlatPlan
-import org.opencypher.caps.api.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.{CypherResult, CypherSession, PropertyGraph}
 import org.opencypher.caps.api.io.{PersistMode, PropertyGraphDataSource}
 import org.opencypher.caps.api.schema.Schema
@@ -28,6 +27,7 @@ import org.opencypher.caps.api.value.CypherValue.CypherMap
 import org.opencypher.caps.cosc.impl.COSCConverters._
 import org.opencypher.caps.cosc.impl.datasource.{COSCGraphSourceHandler, COSCPropertyGraphDataSource, COSCSessionPropertyGraphDataSourceFactory}
 import org.opencypher.caps.cosc.impl.planning.{COSCPhysicalOperatorProducer, COSCPhysicalPlannerContext}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.impl.flat.{FlatPlanner, FlatPlannerContext}
 import org.opencypher.caps.impl.physical.PhysicalPlanner
 import org.opencypher.caps.impl.util.Measurement.time

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCGraphSourceHandler.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCGraphSourceHandler.scala
@@ -17,9 +17,9 @@ package org.opencypher.caps.cosc.impl.datasource
 
 import java.net.URI
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.io.PropertyGraphDataSource
 import org.opencypher.caps.cosc.impl.COSCSession
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 
 case class COSCGraphSourceHandler(
   sessionGraphSourceFactory: COSCSessionPropertyGraphDataSourceFactory,

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCPropertyGraphDataSourceFactoryImpl.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCPropertyGraphDataSourceFactoryImpl.scala
@@ -17,10 +17,10 @@ package org.opencypher.caps.cosc.impl.datasource
 
 import java.net.URI
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.CypherSession
 import org.opencypher.caps.cosc.impl.COSCConverters._
 import org.opencypher.caps.cosc.impl.COSCSession
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 
 abstract class COSCPropertyGraphDataSourceFactoryImpl(val companion: COSCGraphSourceFactoryCompanion)
     extends COSCPropertyGraphDataSourceFactory {

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCSessionPropertyGraphDataSource.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCSessionPropertyGraphDataSource.scala
@@ -17,12 +17,13 @@ package org.opencypher.caps.cosc.impl.datasource
 
 import java.net.URI
 
-import org.opencypher.caps.api.exception.{IllegalArgumentException, UnsupportedOperationException}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.io.{CreateOrFail, Overwrite, PersistMode}
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.cosc.impl.COSCConverters._
 import org.opencypher.caps.cosc.impl.{COSCGraph, COSCSession}
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 
 case class COSCSessionPropertyGraphDataSource(path: String)(implicit val session: COSCSession)
   extends COSCPropertyGraphDataSource {

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCSessionPropertyGraphDataSourceFactory.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/datasource/COSCSessionPropertyGraphDataSourceFactory.scala
@@ -18,9 +18,10 @@ package org.opencypher.caps.cosc.impl.datasource
 import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 
-import org.opencypher.caps.api.exception.{IllegalArgumentException, UnsupportedOperationException}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.CypherSession
 import org.opencypher.caps.cosc.impl.COSCSession
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 
 import scala.collection.JavaConversions._
 

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/planning/COSCOperator.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/planning/COSCOperator.scala
@@ -17,10 +17,10 @@ package org.opencypher.caps.cosc.impl.planning
 
 import java.net.URI
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.physical.PhysicalOperator
 import org.opencypher.caps.cosc.impl.COSCConverters._
 import org.opencypher.caps.cosc.impl.{COSCGraph, COSCPhysicalResult, COSCRecords, COSCRuntimeContext}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.trees.AbstractTreeNode
 
 abstract class COSCOperator extends AbstractTreeNode[COSCOperator]

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/planning/UnaryOperator.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/planning/UnaryOperator.scala
@@ -15,8 +15,10 @@
  */
 package org.opencypher.caps.cosc.impl.planning
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
+import org.opencypher.caps.cosc.impl
+import org.opencypher.caps.cosc.impl.{COSCPhysicalResult, COSCRecords, COSCRuntimeContext}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.cosc.impl.{COSCPhysicalResult, COSCRuntimeContext}
 import org.opencypher.caps.impl.record.RecordHeader
 import org.opencypher.caps.ir.api.expr.{Expr, Var}

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/api/QueryModel.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/api/QueryModel.scala
@@ -17,8 +17,8 @@ package org.opencypher.caps.ir.api
 
 import java.net.URI
 
-import org.opencypher.caps.api.exception.IllegalStateException
 import org.opencypher.caps.api.value.CypherValue._
+import org.opencypher.caps.impl.exception.IllegalStateException
 import org.opencypher.caps.ir.api.block._
 
 import scala.annotation.tailrec

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/api/expr/Expr.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/api/expr/Expr.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.ir.api.expr
 
-import org.opencypher.caps.api.exception.IllegalStateException
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.IllegalStateException
 import org.opencypher.caps.ir.api.{CypherQuery, Label, PropertyKey, RelType}
 
 import scala.annotation.tailrec

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/api/pattern/Pattern.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/api/pattern/Pattern.scala
@@ -18,7 +18,7 @@ package org.opencypher.caps.ir.api.pattern
 import org.opencypher.caps.api.types.{CTNode, CTRelationship, CypherType}
 import org.opencypher.caps.ir.api._
 import org.opencypher.caps.ir.api.block.Binds
-import org.opencypher.caps.ir.api.exception.PatternConversionException
+import org.opencypher.caps.ir.impl.exception.PatternConversionException
 
 import scala.annotation.tailrec
 

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/ExpressionConverter.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/ExpressionConverter.scala
@@ -17,8 +17,8 @@ package org.opencypher.caps.ir.impl
 
 import org.neo4j.cypher.internal.util.v3_4.Ref
 import org.neo4j.cypher.internal.v3_4.{functions, expressions => ast}
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.ir.api.expr._
 import org.opencypher.caps.ir.api.{Label, PropertyKey, RelType}
 import org.opencypher.caps.ir.impl.FunctionUtils._

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/FunctionUtils.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/FunctionUtils.scala
@@ -17,8 +17,8 @@ package org.opencypher.caps.ir.impl
 
 import org.neo4j.cypher.internal.v3_4.expressions.FunctionInvocation
 import org.neo4j.cypher.internal.v3_4.functions
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.types.CypherType
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.ir.api.expr._
 
 object FunctionUtils {

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/IRBuilder.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/IRBuilder.scala
@@ -22,9 +22,10 @@ import org.neo4j.cypher.internal.frontend.v3_4.ast
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 import org.neo4j.cypher.internal.v3_4.expressions.{Expression, StringLiteral, Variable, Pattern => AstPattern}
-import org.opencypher.caps.api.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException}
 import org.opencypher.caps.api.schema.AllGiven
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
 import org.opencypher.caps.impl.util.parsePathOrURI
 import org.opencypher.caps.ir.api._
 import org.opencypher.caps.ir.api.block.{SortItem, _}

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/PatternConverter.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/PatternConverter.scala
@@ -22,8 +22,8 @@ import cats.instances.list._
 import cats.syntax.flatMap._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection.{BOTH, INCOMING, OUTGOING}
 import org.neo4j.cypher.internal.v3_4.{expressions => ast}
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.types.{CTList, CTNode, CTRelationship, CypherType}
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.ir.api._
 import org.opencypher.caps.ir.api.expr.{Expr, Var}
 import org.opencypher.caps.ir.api.pattern._

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/exception/IrException.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/exception/IrException.scala
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opencypher.caps.logical.api.exception
+package org.opencypher.caps.ir.impl.exception
 
-import org.opencypher.caps.api.exception.CypherException
+import org.opencypher.caps.impl.exception.InternalException
 
-abstract class LogicalPlannerException(msg: String) extends CypherException(msg)
+abstract class IrException(msg: String) extends InternalException(msg)
 
-final case class UnsolvedBlockException(msg: String) extends LogicalPlannerException(msg)
+final case class PatternConversionException(msg: String) extends IrException(msg)
 
-final case class InvalidCypherTypeException(msg: String) extends LogicalPlannerException(msg)
+final case class TyperException(msg: String) extends IrException(msg)
 
-final case class InvalidPatternException(msg: String) extends LogicalPlannerException(msg)
-
-final case class InvalidDependencyException(msg: String) extends LogicalPlannerException(msg)
+final case class ParsingException(msg: String) extends IrException(msg)

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/package.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/package.scala
@@ -19,9 +19,9 @@ import cats.data.State
 import org.atnos.eff._
 import org.atnos.eff.all._
 import org.atnos.eff.syntax.all._
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.ir.api.IRField
 import org.opencypher.caps.ir.api.expr.Expr
 import org.opencypher.caps.ir.api.pattern.Pattern

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/parse/CypherParser.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/parse/CypherParser.scala
@@ -20,7 +20,7 @@ import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters._
 import org.neo4j.cypher.internal.frontend.v3_4.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_4.phases._
 import org.neo4j.cypher.internal.frontend.v3_4.semantics._
-import org.opencypher.caps.ir.api.exception.ParsingException
+import org.opencypher.caps.ir.impl.exception.ParsingException
 import org.opencypher.caps.ir.api.util.CompilationStage
 import org.opencypher.caps.ir.impl.parse.rewriter.CAPSRewriting
 

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/refactor/instances/ExprBlockInstances.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/refactor/instances/ExprBlockInstances.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.ir.impl.refactor.instances
 
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.ir.api.block.MatchBlock
 import org.opencypher.caps.ir.api.expr.{Expr, HasLabel, HasType, Var}
 import org.opencypher.caps.ir.api.{IRField, Label}

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/exception/TypingException.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/exception/TypingException.scala
@@ -15,6 +15,6 @@
  */
 package org.opencypher.caps.ir.impl.typer.exception
 
-import org.opencypher.caps.ir.api.exception.IrException
+import org.opencypher.caps.ir.impl.exception.IrException
 
 final case class TypingException(msg: String) extends IrException(msg)

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/package.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/typer/package.scala
@@ -23,7 +23,7 @@ import org.atnos.eff.syntax.all._
 import org.neo4j.cypher.internal.v3_4.expressions.Expression
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types._
-import org.opencypher.caps.ir.api.exception.TyperException
+import org.opencypher.caps.ir.impl.exception.TyperException
 
 package object typer {
 

--- a/caps-ir/src/test/scala/org/opencypher/caps/ir/api/QueryModelTest.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/ir/api/QueryModelTest.scala
@@ -15,7 +15,7 @@
  */
 package org.opencypher.caps.ir.api
 
-import org.opencypher.caps.api.exception.IllegalStateException
+import org.opencypher.caps.impl.exception.IllegalStateException
 import org.opencypher.caps.ir.api.block._
 import org.opencypher.caps.ir.impl.IrTestSuite
 

--- a/caps-ir/src/test/scala/org/opencypher/caps/ir/api/expr/AndsTest.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/ir/api/expr/AndsTest.scala
@@ -15,7 +15,7 @@
  */
 package org.opencypher.caps.ir.api.expr
 
-import org.opencypher.caps.api.exception.IllegalStateException
+import org.opencypher.caps.impl.exception.IllegalStateException
 import org.opencypher.caps.ir.api.Label
 import org.opencypher.caps.test.BaseTestSuite
 

--- a/caps-ir/src/test/scala/org/opencypher/caps/ir/test/support/Neo4jAstTestSupport.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/ir/test/support/Neo4jAstTestSupport.scala
@@ -22,7 +22,7 @@ import org.neo4j.cypher.internal.frontend.v3_4.phases._
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticState}
 import org.neo4j.cypher.internal.util.v3_4.{CypherException, InputPosition}
 import org.neo4j.cypher.internal.v3_4.expressions.Expression
-import org.opencypher.caps.api.exception.IllegalArgumentException
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.ir.impl.parse.CypherParser
 import org.opencypher.caps.test.BaseTestSuite
 

--- a/caps-ir/src/test/scala/org/opencypher/caps/test/support/creation/propertygraph/TestPropertyGraphFactory.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/test/support/creation/propertygraph/TestPropertyGraphFactory.scala
@@ -25,8 +25,8 @@ import cats.syntax.all._
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.util.v3_4.ASTNode
 import org.neo4j.cypher.internal.v3_4.expressions._
-import org.opencypher.caps.api.exception.{IllegalArgumentException, UnsupportedOperationException}
 import org.opencypher.caps.api.value.CypherValue.{CypherEntity, CypherMap, CypherNode, CypherRelationship}
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 import org.opencypher.caps.ir.impl.parse.CypherParser
 
 import scala.collection.TraversableOnce

--- a/caps-logical/src/main/scala/org/opencypher/caps/logical/impl/LogicalPlanner.scala
+++ b/caps-logical/src/main/scala/org/opencypher/caps/logical/impl/LogicalPlanner.scala
@@ -15,9 +15,9 @@
  */
 package org.opencypher.caps.logical.impl
 
-import org.opencypher.caps.api.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
 import org.opencypher.caps.api.schema.{AllGiven, Schema}
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
 import org.opencypher.caps.ir.api.block._
 import org.opencypher.caps.ir.api.expr._
 import org.opencypher.caps.ir.api.pattern._
@@ -25,7 +25,7 @@ import org.opencypher.caps.ir.api.util.DirectCompilationStage
 import org.opencypher.caps.ir.api.{Label, _}
 import org.opencypher.caps.ir.impl.syntax.ExprSyntax._
 import org.opencypher.caps.ir.impl.util.VarConverters._
-import org.opencypher.caps.logical.api.exception.{InvalidCypherTypeException, InvalidDependencyException, InvalidPatternException}
+import org.opencypher.caps.logical.impl.exception.{InvalidCypherTypeException, InvalidDependencyException, InvalidPatternException}
 
 import scala.annotation.tailrec
 

--- a/caps-logical/src/main/scala/org/opencypher/caps/logical/impl/SolvedQueryModel.scala
+++ b/caps-logical/src/main/scala/org/opencypher/caps/logical/impl/SolvedQueryModel.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.caps.logical.impl
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types.{CTBoolean, CTRelationship}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.ir.api.block.Block
 import org.opencypher.caps.ir.api.expr.{Expr, HasType, Ors}
 import org.opencypher.caps.ir.api.pattern.Pattern

--- a/caps-logical/src/main/scala/org/opencypher/caps/logical/impl/exception/LogicalPlannerException.scala
+++ b/caps-logical/src/main/scala/org/opencypher/caps/logical/impl/exception/LogicalPlannerException.scala
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opencypher.caps.api.exception
+package org.opencypher.caps.logical.impl.exception
 
-import org.opencypher.caps.ir.api.expr.Var
+import org.opencypher.caps.impl.exception.InternalException
 
-abstract class CoraException(msg: String) extends CypherException(msg)
+abstract class LogicalPlannerException(msg: String) extends InternalException(msg)
 
-final case class RecordHeaderException(msg: String) extends CoraException(msg)
+final case class UnsolvedBlockException(msg: String) extends LogicalPlannerException(msg)
 
-final case class DuplicateSourceColumnException(columnName: String, entity: Var)
-    extends CoraException(
-          s"The source column '$columnName' is used more than once to describe the mapping of $entity")
+final case class InvalidCypherTypeException(msg: String) extends LogicalPlannerException(msg)
+
+final case class InvalidPatternException(msg: String) extends LogicalPlannerException(msg)
+
+final case class InvalidDependencyException(msg: String) extends LogicalPlannerException(msg)

--- a/caps-logical/src/test/scala/org/opencypher/caps/logical/impl/SolvedQueryModelTest.scala
+++ b/caps-logical/src/test/scala/org/opencypher/caps/logical/impl/SolvedQueryModelTest.scala
@@ -17,9 +17,9 @@ package org.opencypher.caps.logical.impl
 
 import java.net.URI
 
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types.{CTBoolean, CTNode, CTRelationship}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.ir.api.block.{FieldsAndGraphs, ProjectedFieldsOf}
 import org.opencypher.caps.ir.api.expr.{Equals, Expr, _}
 import org.opencypher.caps.ir.api.pattern.Pattern

--- a/caps-spark/src/main/scala/org/opencypher/caps/api/CAPSSession.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/api/CAPSSession.scala
@@ -20,12 +20,12 @@ import java.util.{ServiceLoader, UUID}
 import org.apache.spark.SparkConf
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.SparkSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.{CypherSession, PropertyGraph}
 import org.opencypher.caps.api.schema.EntityTable.SparkTable
 import org.opencypher.caps.api.schema._
 import org.opencypher.caps.demo.CypherKryoRegistrar
 import org.opencypher.caps.impl.record.CypherRecords
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark._
 import org.opencypher.caps.impl.spark.io.{CAPSGraphSourceHandler, CAPSPropertyGraphDataSourceFactory}
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/api/schema/EntityTable.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/api/schema/EntityTable.scala
@@ -18,13 +18,13 @@ package org.opencypher.caps.api.schema
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.storage.StorageLevel
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.io.conversion.{EntityMapping, NodeMapping, RelationshipMapping}
 import org.opencypher.caps.api.schema.Entity.sourceIdKey
 import org.opencypher.caps.api.schema.EntityTable._
 import org.opencypher.caps.api.types._
 import org.opencypher.caps.api.value.CypherValue
 import org.opencypher.caps.api.value.CypherValue.CypherValue
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.CypherTable
 import org.opencypher.caps.impl.spark._
 import org.opencypher.caps.impl.spark.convert.SparkUtils

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/record/CAPSRecordHeader.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/record/CAPSRecordHeader.scala
@@ -18,7 +18,7 @@ package org.opencypher.caps.impl.record
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.types.{StructField, StructType}
-import org.opencypher.caps.api.exception.IllegalArgumentException
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.convert.SparkUtils._
 import org.opencypher.caps.ir.api.expr.Var
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSConverters.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSConverters.scala
@@ -16,8 +16,8 @@
 package org.opencypher.caps.impl.spark
 
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.{CypherResult, CypherSession, PropertyGraph}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.impl.record.{CypherRecordHeader, CypherRecords, RecordHeader}
 
 object CAPSConverters {

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSGraph.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSGraph.scala
@@ -17,10 +17,10 @@ package org.opencypher.caps.impl.spark
 
 import org.apache.spark.storage.StorageLevel
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.schema._
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.{OpaqueField, RecordHeader, _}
 import org.opencypher.caps.impl.spark.CAPSConverters._
 import org.opencypher.caps.ir.api.expr._

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
@@ -24,12 +24,13 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.{DuplicateSourceColumnException, IllegalArgumentException, IllegalStateException}
+import org.opencypher.caps.impl.exception.DuplicateSourceColumnException
 import org.opencypher.caps.api.io.conversion.{NodeMapping, RelationshipMapping}
 import org.opencypher.caps.api.schema.EntityTable._
 import org.opencypher.caps.api.schema.{CAPSEntityTable, CAPSNodeTable, CAPSRelationshipTable}
 import org.opencypher.caps.api.types._
 import org.opencypher.caps.api.value.CypherValue.{CypherMap, CypherValue}
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException}
 import org.opencypher.caps.impl.record.CAPSRecordHeader._
 import org.opencypher.caps.impl.record.{CAPSRecordHeader, _}
 import org.opencypher.caps.impl.spark.CAPSRecords.{prepareDataFrame, verifyAndCreate}

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSScanGraph.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSScanGraph.scala
@@ -18,10 +18,10 @@ package org.opencypher.caps.impl.spark
 import cats.data.NonEmptyVector
 import org.apache.spark.storage.StorageLevel
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.schema._
 import org.opencypher.caps.api.types.{CTNode, CTRelationship, CypherType, DefiniteCypherType}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.RecordHeader
 import org.opencypher.caps.impl.spark.CAPSConverters._
 import org.opencypher.caps.ir.api.expr._

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSSessionImpl.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSSessionImpl.scala
@@ -21,12 +21,12 @@ import java.util.UUID
 import org.apache.spark.sql.SparkSession
 import org.opencypher.caps.api.CAPSSession
 import org.opencypher.caps.api.configuration.CoraConfiguration.{PrintPhysicalPlan, PrintQueryExecutionStages}
-import org.opencypher.caps.api.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.{CypherResult, PropertyGraph}
 import org.opencypher.caps.api.io.{CreateOrFail, PersistMode, PropertyGraphDataSource}
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.value.CypherValue._
 import org.opencypher.caps.api.value._
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.impl.flat.{FlatPlanner, FlatPlannerContext}
 import org.opencypher.caps.impl.physical.PhysicalPlanner
 import org.opencypher.caps.impl.record.CypherRecords

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/DfUtils.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/DfUtils.scala
@@ -16,9 +16,9 @@
 package org.opencypher.caps.impl.spark
 
 import org.apache.spark.sql.{Column, DataFrame, Row}
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.value.CypherValue._
 import org.opencypher.caps.api.value._
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.{ColumnName, RecordHeader}
 import org.opencypher.caps.impl.spark.physical.CAPSRuntimeContext
 import org.opencypher.caps.ir.api.expr.{Expr, Param}

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/RowExpansion.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/RowExpansion.scala
@@ -17,8 +17,8 @@ package org.opencypher.caps.impl.spark
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.StructType
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.CAPSRecordHeader._
 import org.opencypher.caps.impl.record.{ColumnName, ProjectedExpr, RecordHeader, RecordSlot}
 import org.opencypher.caps.ir.api.expr._

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/SparkSQLExprMapper.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/SparkSQLExprMapper.scala
@@ -17,9 +17,10 @@ package org.opencypher.caps.impl.spark
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.types._
-import org.opencypher.caps.api.exception._
+import org.opencypher.caps.impl.exception._
 import org.opencypher.caps.api.types._
 import org.opencypher.caps.api.value.CypherValue._
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
 import org.opencypher.caps.impl.record.RecordHeader
 import org.opencypher.caps.impl.spark.CAPSFunctions._
 import org.opencypher.caps.impl.spark.convert.SparkUtils._

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/convert/SparkUtils.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/convert/SparkUtils.scala
@@ -17,8 +17,9 @@ package org.opencypher.caps.impl.spark.convert
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
-import org.opencypher.caps.api.exception.{IllegalArgumentException, NotImplementedException}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, NotImplementedException}
 
 object SparkUtils {
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/convert/rowToCypherMap.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/convert/rowToCypherMap.scala
@@ -16,10 +16,10 @@
 package org.opencypher.caps.impl.spark.convert
 
 import org.apache.spark.sql.Row
-import org.opencypher.caps.api.exception.UnsupportedOperationException
 import org.opencypher.caps.api.types.{CTNode, CTRelationship}
 import org.opencypher.caps.api.value.CypherValue._
 import org.opencypher.caps.api.value._
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.impl.record.{ColumnName, RecordHeader}
 import org.opencypher.caps.ir.api.expr.Var
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/CAPSGraphSourceHandler.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/CAPSGraphSourceHandler.scala
@@ -18,9 +18,10 @@ package org.opencypher.caps.impl.spark.io
 import java.net.URI
 
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.{IllegalArgumentException, IllegalStateException}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.CypherSession
 import org.opencypher.caps.api.io.PropertyGraphDataSource
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException}
 import org.opencypher.caps.impl.spark.io.session.SessionPropertyGraphDataSourceFactory
 
 object CAPSGraphSourceHandler {

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/CAPSPropertyGraphDataSourceFactoryImpl.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/CAPSPropertyGraphDataSourceFactoryImpl.scala
@@ -18,8 +18,8 @@ package org.opencypher.caps.impl.spark.io
 import java.net.URI
 
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.CypherSession
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.CAPSConverters._
 
 abstract class CAPSPropertyGraphDataSourceFactoryImpl(val companion: CAPSGraphSourceFactoryCompanion)

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/file/FileCsvPropertyGraphDataSource.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/file/FileCsvPropertyGraphDataSource.scala
@@ -18,10 +18,10 @@ package org.opencypher.caps.impl.spark.io.file
 import java.net.URI
 
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.io.{CreateOrFail, PersistMode}
 import org.opencypher.caps.api.schema.Schema
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.impl.spark.CAPSGraph
 import org.opencypher.caps.impl.spark.io.CAPSPropertyGraphDataSource
 import org.opencypher.caps.impl.spark.io.hdfs.CsvGraphLoader

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/hdfs/CsvGraphLoader.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/hdfs/CsvGraphLoader.scala
@@ -25,10 +25,10 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession, functions}
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.io.conversion.{NodeMapping, RelationshipMapping}
 import org.opencypher.caps.api.schema.{CAPSNodeTable, CAPSRelationshipTable}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.convert.SparkUtils.NullabilityOps
 
 trait CsvGraphLoaderFileHandler {

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/hdfs/HdfsCsvPropertyGraphDataSource.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/hdfs/HdfsCsvPropertyGraphDataSource.scala
@@ -19,10 +19,10 @@ import java.net.URI
 
 import org.apache.hadoop.conf.Configuration
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.io.{CreateOrFail, PersistMode}
 import org.opencypher.caps.api.schema.Schema
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.CAPSGraph
 import org.opencypher.caps.impl.spark.io.CAPSPropertyGraphDataSource
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/neo4j/Neo4JPropertyGraphDataSourceFactory.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/neo4j/Neo4JPropertyGraphDataSourceFactory.scala
@@ -19,7 +19,7 @@ import java.net.{URI, URLDecoder}
 
 import org.apache.http.client.utils.URIBuilder
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.io.{CAPSGraphSourceFactoryCompanion, CAPSPropertyGraphDataSourceFactoryImpl}
 import org.opencypher.caps.impl.spark.io.neo4j.external.Neo4jConfig
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/neo4j/Neo4jGraph.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/neo4j/Neo4jGraph.scala
@@ -21,11 +21,12 @@ import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.neo4j.driver.internal.{InternalNode, InternalRelationship}
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.{IllegalArgumentException, UnsupportedOperationException}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types.{CTNode, CTRelationship, CypherType}
 import org.opencypher.caps.api.value.CypherValue
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 import org.opencypher.caps.impl.record.{CAPSRecordHeader, ColumnName, RecordHeader}
 import org.opencypher.caps.impl.spark.io.neo4j.Neo4jGraph.{filterNode, filterRel, nodeToRow, relToRow}
 import org.opencypher.caps.impl.spark.{CAPSGraph, CAPSRecords}

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/neo4j/external/Neo4j.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/neo4j/external/Neo4j.scala
@@ -17,7 +17,7 @@ package org.opencypher.caps.impl.spark.io.neo4j.external
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
-import org.opencypher.caps.api.exception.IllegalArgumentException
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.io.neo4j.external.Neo4j._
 
 import scala.reflect.ClassTag

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/session/SessionPropertyGraphDataSource.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/session/SessionPropertyGraphDataSource.scala
@@ -18,10 +18,11 @@ package org.opencypher.caps.impl.spark.io.session
 import java.net.URI
 
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.{IllegalArgumentException, UnsupportedOperationException}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.PropertyGraph
 import org.opencypher.caps.api.io.{CreateOrFail, Overwrite, PersistMode}
 import org.opencypher.caps.api.schema.Schema
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 import org.opencypher.caps.impl.spark.CAPSConverters._
 import org.opencypher.caps.impl.spark.CAPSGraph
 import org.opencypher.caps.impl.spark.io.CAPSPropertyGraphDataSource

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/session/SessionPropertyGraphDataSourceFactory.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/io/session/SessionPropertyGraphDataSourceFactory.scala
@@ -19,8 +19,9 @@ import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.{IllegalArgumentException, UnsupportedOperationException}
+import org.opencypher.caps.impl.exception.UnsupportedOperationException
 import org.opencypher.caps.api.graph.CypherSession
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
 import org.opencypher.caps.impl.spark.io.{CAPSPropertyGraphDataSourceFactoryImpl, _}
 
 import scala.collection.JavaConversions._

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/physical/operators/CAPSPhysicalOperator.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/physical/operators/CAPSPhysicalOperator.scala
@@ -19,9 +19,9 @@ import java.net.URI
 
 import org.apache.spark.sql.DataFrame
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.physical.PhysicalOperator
 import org.opencypher.caps.api.types._
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.{ColumnName, RecordHeader, RecordSlot, SlotContent}
 import org.opencypher.caps.impl.spark.CAPSConverters._
 import org.opencypher.caps.impl.spark.physical.DataFrameOps._

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/physical/operators/UnaryOperators.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/physical/operators/UnaryOperators.scala
@@ -21,10 +21,11 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{asc, desc, monotonically_increasing_id}
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.opencypher.caps.api.CAPSSession
-import org.opencypher.caps.api.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException}
 import org.opencypher.caps.api.schema.Schema
 import org.opencypher.caps.api.types._
 import org.opencypher.caps.api.value.CypherValue._
+import org.opencypher.caps.impl.exception.{IllegalArgumentException, IllegalStateException, NotImplementedException}
 import org.opencypher.caps.impl.record._
 import org.opencypher.caps.impl.spark.SparkSQLExprMapper._
 import org.opencypher.caps.impl.spark.convert.SparkUtils._

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/record/EntityTableTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/record/EntityTableTest.scala
@@ -17,12 +17,12 @@ package org.opencypher.caps.impl.record
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.DecimalType
-import org.opencypher.caps.api.exception.IllegalArgumentException
 import org.opencypher.caps.api.io.conversion.{NodeMapping, RelationshipMapping}
 import org.opencypher.caps.api.schema.{CAPSNodeTable, CAPSRelationshipTable, Schema}
 import org.opencypher.caps.api.types.{CTFloat, CTInteger, CTString}
 import org.opencypher.caps.api.value.CypherValue.CypherMap
 import org.opencypher.caps.demo.SocialNetworkData.{Friend, Person}
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.spark.CAPSGraph
 import org.opencypher.caps.impl.spark.convert.SparkUtils
 import org.opencypher.caps.test.CAPSTestSuite

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsAcceptanceTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsAcceptanceTest.scala
@@ -16,7 +16,7 @@
 package org.opencypher.caps.impl.spark
 
 import org.apache.spark.sql.Row
-import org.opencypher.caps.api.exception.IllegalArgumentException
+import org.opencypher.caps.impl.exception.IllegalArgumentException
 import org.opencypher.caps.impl.record.CypherRecords
 import org.opencypher.caps.impl.spark.CAPSConverters._
 import org.opencypher.caps.impl.spark.io.neo4j.Neo4jGraphLoader

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
@@ -16,7 +16,7 @@
 package org.opencypher.caps.impl.spark
 
 import org.apache.spark.sql.Row
-import org.opencypher.caps.api.exception.CypherException
+import org.opencypher.caps.impl.exception.InternalException
 import org.opencypher.caps.api.io.conversion.{NodeMapping, RelationshipMapping}
 import org.opencypher.caps.api.schema.{CAPSNodeTable, CAPSRelationshipTable}
 import org.opencypher.caps.api.types._
@@ -153,7 +153,7 @@ class CAPSRecordsTest extends CAPSTestSuite with GraphCreationFixture with TeamD
     val data = session.createDataFrame(Seq((1, "foo"), (2, "bar"))).toDF("int", "string")
     val header = RecordHeader.from(OpaqueField(Var("int")()), OpaqueField(Var("notString")()))
 
-    a[CypherException] shouldBe thrownBy {
+    a[InternalException] shouldBe thrownBy {
       CAPSRecords.verifyAndCreate(header, data)
     }
   }

--- a/caps-tck/src/test/scala/org/opencypher/caps/tck/TCKFixture.scala
+++ b/caps-tck/src/test/scala/org/opencypher/caps/tck/TCKFixture.scala
@@ -15,10 +15,10 @@
  */
 package org.opencypher.caps.tck
 
-import org.opencypher.caps.api.exception.NotImplementedException
 import org.opencypher.caps.api.graph.{CypherSession, PropertyGraph}
 import org.opencypher.caps.api.value.CypherValue
 import org.opencypher.caps.api.value.CypherValue.{CypherList => CAPSCypherList, CypherMap => CAPSCypherMap, CypherValue => CAPSCypherValue}
+import org.opencypher.caps.impl.exception.NotImplementedException
 import org.opencypher.caps.impl.record.CypherRecords
 import org.opencypher.caps.ir.impl.typer.exception.TypingException
 import org.opencypher.caps.tck.TCKFixture._


### PR DESCRIPTION
We should try to use TCK compatible exceptions for all failure modes specified by the TCK. Internal exceptions that should be user-facing need to be refactored and moved back to the API package. Most likely this will involve creating new categories of exceptions related to importing data and instantiating sessions. Inside of the API package of the CAPS/CORA modules, there should be exceptions specific to the limitations of the implementations (e.g. schema constraints).