### PR TITLE
Implement evaluation of distinct collect and count

### DIFF
--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/api/expr/Expr.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/api/expr/Expr.scala
@@ -300,7 +300,7 @@ final case class CountStar(cypherType: CypherType = CTWildcard) extends Aggregat
   override def toString = "count(*)"
 }
 
-final case class Count(expr: Expr)(val cypherType: CypherType = CTWildcard) extends Aggregator {
+final case class Count(expr: Expr, distinct: Boolean)(val cypherType: CypherType = CTWildcard) extends Aggregator {
   override val inner: Option[Expr] = Some(expr)
 
   override def toString = s"count($expr)"
@@ -332,7 +332,7 @@ final case class Sum(expr: Expr)(val cypherType: CypherType = CTWildcard) extend
   override def withoutType: String = s"sum(${expr.withoutType})"
 }
 
-final case class Collect(expr: Expr)(val cypherType: CypherType = CTWildcard) extends Aggregator {
+final case class Collect(expr: Expr, distinct: Boolean)(val cypherType: CypherType = CTWildcard) extends Aggregator {
   override val inner: Option[Expr] = Some(expr)
 
   override def toString = s"collect($expr)"

--- a/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/FunctionUtils.scala
+++ b/caps-ir/src/main/scala/org/opencypher/caps/ir/impl/FunctionUtils.scala
@@ -25,12 +25,14 @@ object FunctionUtils {
 
   implicit class RichFunctionInvocation(functionInvocation: FunctionInvocation) {
     def toCAPSFunction(expr: IndexedSeq[Expr], cypherType: CypherType): Expr = {
+      val distinct = functionInvocation.distinct
+
       functionInvocation.function match {
         case functions.Id        => Id(expr.head)(cypherType)
         case functions.Labels    => Labels(expr.head)(cypherType)
         case functions.Type      => Type(expr.head)(cypherType)
         case functions.Avg       => Avg(expr.head)(cypherType)
-        case functions.Count     => Count(expr.head)(cypherType)
+        case functions.Count     => Count(expr.head, distinct)(cypherType)
         case functions.Max       => Max(expr.head)(cypherType)
         case functions.Min       => Min(expr.head)(cypherType)
         case functions.Sum       => Sum(expr.head)(cypherType)
@@ -40,7 +42,7 @@ object FunctionUtils {
         case functions.StartNode => StartNodeFunction(expr.head)(cypherType)
         case functions.EndNode   => EndNodeFunction(expr.head)(cypherType)
         case functions.ToFloat   => ToFloat(expr.head)(cypherType)
-        case functions.Collect   => Collect(expr.head)(cypherType)
+        case functions.Collect   => Collect(expr.head, distinct)(cypherType)
         case functions.Coalesce  => Coalesce(expr)(cypherType)
         case a: functions.Function =>
           throw NotImplementedException(s"Support for converting ${a.name} function not yet implemented")

--- a/caps-ir/src/test/scala/org/opencypher/caps/ir/impl/ExpressionConverterTest.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/ir/impl/ExpressionConverterTest.scala
@@ -81,7 +81,7 @@ class ExpressionConverterTest extends BaseTestSuite with Neo4jAstTestSupport wit
 
   test("convert count") {
     convert(parseExpr("count(a)")) should equal(
-      Count(Var("a")())()
+      Count(Var("a")(), false)()
     )
     convert(parseExpr("count(*)")) should equal(
       CountStar()

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/AggregationBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/AggregationBehaviour.scala
@@ -237,6 +237,27 @@ trait AggregationBehaviour {
           CypherMap("name" -> null, "age" -> null, "amount" -> 2)
         ))
       }
+
+      it("counts distinct with grouping") {
+        val graph = initGraph(
+          """
+            |CREATE (a:Start{id: 1})
+            |CREATE (a)-[:REL]->({val: "foo"})
+            |CREATE (a)-[:REL]->({val: "foo"})
+          """.stripMargin)
+
+        val result = graph.cypher(
+          """
+            |MATCH (a:Start)-->(b)
+            |
+            |RETURN a.id,
+            |       count(distinct b.val) as val
+          """.stripMargin)
+
+        result.records.toMaps should equal(Bag(
+          CypherMap("a.id" -> 1, "val" -> 1)
+        ))
+      }
     }
 
     describe("MIN") {
@@ -540,6 +561,27 @@ trait AggregationBehaviour {
 
         result.records.toMaps should equal(Bag(
           CypherMap("res" -> Seq.empty)
+        ))
+      }
+
+      it("collects distinct lists with grouping") {
+        val graph = initGraph(
+          """
+            |CREATE (a:Start{id: 1})
+            |CREATE (a)-[:REL]->({val: "foo"})
+            |CREATE (a)-[:REL]->({val: "foo"})
+          """.stripMargin)
+
+        val result = graph.cypher(
+          """
+            |MATCH (a:Start)-->(b)
+            |
+            |RETURN a.id,
+            |       collect(distinct b.val) as val
+          """.stripMargin)
+
+        result.records.toMaps should equal(Bag(
+          CypherMap("a.id" -> 1, "val" -> CypherList("foo"))
         ))
       }
     }


### PR DESCRIPTION
Allows evaluation of

```
MATCH (a)-->(b)
RETURN a,
                COLLECT(DISTINCT v.val) as list,
                COUNT(DISTINCT v.val2) as count
```

Distinct evaluation of average and sum are not supported by spark