### PR TITLE
Add collect method to CypherRecords

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ object CaseClassExample extends App {
   )
 
   // 4) Convert to maps and print to console
-  println(results.records.iterator.mkString("\n"))
+  println(results.records.collect.mkString("\n"))
 }
 
 /**

--- a/caps-api/src/main/scala/org/opencypher/caps/api/table/CypherRecords.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/table/CypherRecords.scala
@@ -27,7 +27,7 @@ trait CypherRecords extends CypherTable[String] with CypherPrintable {
   /**
     * Consume these records as an iterator.
     *
-    * WARNING: This operation may be very expensive as it may have to materialise
+    * WARNING: This operation may be very expensive as it may have to materialise the full result set.
     *
     * @note This method may be considerably slower than [[org.opencypher.caps.api.table.CypherRecords#collect]].
     *       Use this method only if collect could outgrow the available driver memory.
@@ -37,7 +37,7 @@ trait CypherRecords extends CypherTable[String] with CypherPrintable {
   /**
     * Consume these records and collect them into an array.
     *
-    * WARNING: This operation may be very expensive as it may have to materialise
+    * WARNING: This operation may be very expensive as it may have to materialise the full result set.
     */
   def collect: Array[CypherMap]
 

--- a/caps-api/src/main/scala/org/opencypher/caps/api/table/CypherRecords.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/api/table/CypherRecords.scala
@@ -28,8 +28,18 @@ trait CypherRecords extends CypherTable[String] with CypherPrintable {
     * Consume these records as an iterator.
     *
     * WARNING: This operation may be very expensive as it may have to materialise
+    *
+    * @note This method may be considerably slower than [[org.opencypher.caps.api.table.CypherRecords#collect]].
+    *       Use this method only if collect could outgrow the available driver memory.
     */
   def iterator: Iterator[CypherMap]
+
+  /**
+    * Consume these records and collect them into an array.
+    *
+    * WARNING: This operation may be very expensive as it may have to materialise
+    */
+  def collect: Array[CypherMap]
 
   /**
     * Registers these records as a table under the given name.

--- a/caps-api/src/main/scala/org/opencypher/caps/impl/table/RecordsPrinter.scala
+++ b/caps-api/src/main/scala/org/opencypher/caps/impl/table/RecordsPrinter.scala
@@ -49,7 +49,7 @@ object RecordsPrinter {
 
     sep = "| "
     var count = 0
-    records.iterator.foreach { map =>
+    records.collect.foreach { map =>
       if (fieldContents.isEmpty) {
         stream.print(sep)
         stream.print(fitToColumn("(empty row)"))

--- a/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCRecords.scala
+++ b/caps-cosc/src/main/scala/org/opencypher/caps/cosc/impl/COSCRecords.scala
@@ -63,6 +63,13 @@ sealed abstract class COSCRecords(
     * @param name the name under which this table may be referenced.
     */
   override def register(name: String): Unit = ???
+
+  /**
+    * Consume these records and collect them into an array.
+    *
+    * WARNING: This operation may be very expensive as it may have to materialise
+    */
+  override def collect: Array[CypherMap] = data.rows.toArray
 }
 
 

--- a/caps-examples/src/main/scala/org/opencypher/spark/examples/CaseClassExample.scala
+++ b/caps-examples/src/main/scala/org/opencypher/spark/examples/CaseClassExample.scala
@@ -36,7 +36,7 @@ object CaseClassExample extends App {
   )
 
   // 4) Convert to maps and print to console
-  println(results.records.iterator.mkString("\n"))
+  println(results.records.collect.mkString("\n"))
 }
 
 /**

--- a/caps-examples/src/main/scala/org/opencypher/spark/examples/DataFrameInputExample.scala
+++ b/caps-examples/src/main/scala/org/opencypher/spark/examples/DataFrameInputExample.scala
@@ -62,9 +62,9 @@ object DataFrameInputExample extends App {
   // 6) Collect results into string by selecting a specific column.
   //    This operation may be very expensive as it materializes results locally.
   // 6a) type safe version, discards values with wrong type
-  val safeNames: Set[String] = result.records.iterator.flatMap(_ ("n.name").as[String]).toSet
+  val safeNames: Set[String] = result.records.collect.flatMap(_ ("n.name").as[String]).toSet
   // 6b) unsafe version, throws an exception when value cannot be cast
-  val unsafeNames: Set[String] = result.records.iterator.map(_ ("n.name").cast[String]).toSet
+  val unsafeNames: Set[String] = result.records.collect.map(_ ("n.name").cast[String]).toSet
 
   println(safeNames)
 }

--- a/caps-ir/src/test/scala/org/opencypher/caps/test/support/DebugOutputSupport.scala
+++ b/caps-ir/src/test/scala/org/opencypher/caps/test/support/DebugOutputSupport.scala
@@ -24,4 +24,9 @@ trait DebugOutputSupport {
     implicit val m: HashedBagConfiguration[T] = Bag.configuration.compact[T]
     def toBag: Bag[T] = Bag(elements.toSeq: _*)
   }
+
+  implicit class ArrayToBagConverter[T](val elements: Array[T]) {
+    implicit val m: HashedBagConfiguration[T] = Bag.configuration.compact[T]
+    def toBag: Bag[T] = Bag(elements.toSeq: _*)
+  }
 }

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
@@ -142,7 +142,7 @@ sealed abstract class CAPSRecords(val header: RecordHeader, val data: DataFrame)
   }
 
   def toLocalIterator: java.util.Iterator[CypherMap] = {
-    toCypherMaps.collect().toIterator.asJava
+    toCypherMaps.toLocalIterator()
   }
 
   def foreachPartition(f: Iterator[CypherMap] => Unit): Unit = {

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/spark/CAPSRecords.scala
@@ -142,14 +142,14 @@ sealed abstract class CAPSRecords(val header: RecordHeader, val data: DataFrame)
   }
 
   def toLocalIterator: java.util.Iterator[CypherMap] = {
-    toCypherMaps.toLocalIterator()
+    toCypherMaps.collect().toIterator.asJava
   }
 
   def foreachPartition(f: Iterator[CypherMap] => Unit): Unit = {
     toCypherMaps.foreachPartition(f)
   }
 
-  def collect(): Array[CypherMap] =
+  override def collect: Array[CypherMap] =
     toCypherMaps.collect()
 
   /**

--- a/caps-spark/src/main/scala/org/opencypher/caps/impl/util/ZeppelinSupport.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/impl/util/ZeppelinSupport.scala
@@ -47,7 +47,7 @@ object ZeppelinSupport {
       val fields = result.records.header.fieldsInOrder
 
       val header = fields.mkString("\t")
-      val rows = result.records.iterator.map { data =>
+      val rows = result.records.collect.map { data =>
         fields.map(field => data.get(field).get).mkString("\t")
       }.mkString("\n")
 

--- a/caps-spark/src/main/scala/org/opencypher/caps/web/CAPSJsonSerialiser.scala
+++ b/caps-spark/src/main/scala/org/opencypher/caps/web/CAPSJsonSerialiser.scala
@@ -24,7 +24,7 @@ import org.opencypher.caps.impl.spark.{CAPSGraph, CAPSRecords}
 trait JsonSerialiser {
   implicit val recordsEncoder: Encoder[CAPSRecords] = new Encoder[CAPSRecords] {
     override final def apply(records: CAPSRecords): Json = {
-      val rows = records.iterator.map { map =>
+      val rows = records.collect.map { map =>
         val unit = records.header.fieldsInOrder.map { field =>
           field -> constructValue(map(field))
         }
@@ -40,11 +40,11 @@ trait JsonSerialiser {
 
   implicit val graphEncoder: Encoder[CAPSGraph] = new Encoder[CAPSGraph] {
     override final def apply(graph: CAPSGraph): Json = {
-      val nodes = graph.nodes("n").iterator.map { map =>
+      val nodes = graph.nodes("n").collect.map { map =>
         constructValue(map("n"))
       }.toSeq
 
-      val rels = graph.relationships("rel").iterator.map { map =>
+      val rels = graph.relationships("rel").collect.map { map =>
         constructValue(map("rel"))
       }.toSeq
 

--- a/caps-spark/src/test/scala/org/opencypher/caps/demo/GCDemoTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/demo/GCDemoTest.scala
@@ -104,7 +104,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
     //Write back to Neo
     withBoltSession { session =>
       // maybe iterate over rows instead of CypherMaps is faster
-      result.records.iterator.foreach { cypherMap =>
+      result.records.collect.foreach { cypherMap =>
         session.run(
           s"MATCH (p:Person {name: ${cypherMap.get("name").get}}) SET p.should_buy = ${cypherMap.get("product").get}")
       }
@@ -118,7 +118,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
     val SN_US = neoRegionGraph("US")
     val result = SN_US.cypher("""MATCH (n:Person {name: "Alice"}) RETURN n.name AS name""")
     withBoltSession { session =>
-      result.records.iterator.foreach { cypherMap =>
+      result.records.collect.foreach { cypherMap =>
         session.run(s"MATCH (p:Person {name: ${cypherMap.get("name").get.toCypherString}}) SET p.should_buy = 'a book'")
       }
     }
@@ -126,7 +126,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
     val resultGraph = neoRegionGraph("US")
     val res = resultGraph.cypher("MATCH (n:Person {name: 'Alice'}) RETURN n.should_buy as rec")
 
-    res.records.iterator.toSet should equal(
+    res.records.collect.toSet should equal(
       Set(
         CypherMap("rec" -> "a book")
       ))
@@ -199,7 +199,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
         .withRelationshipPropertyKeys("HAS_INTEREST")("region" -> CTString)
         .withRelationshipPropertyKeys("KNOWS")("region" -> CTString))
 
-    graph.nodes("n").iterator.toBag should equal(
+    graph.nodes("n").collect.toBag should equal(
       Bag(
         Row(2009L, false, false, true, false, false, "Trent", null, null, null, null),
         Row(1L, true, false, false, false, false, "San Francisco", null, "US", null, null),
@@ -335,7 +335,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
         .withNodePropertyKeys("Customer")("name" -> CTString.nullable)
         .withRelationshipType("IN"))
 
-    graph.nodes("n").iterator.toBag should equal(
+    graph.nodes("n").collect.toBag should equal(
       Bag(
         Row(7L, true, false, "Alice", "US"),
         Row(2001L, false, true, "Alice", null),
@@ -389,7 +389,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
         .withNodePropertyKeys("Person")("name" -> CTString, "region" -> CTString)
         .withRelationshipType("ACQUAINTED"))
 
-    g.nodes("n").iterator.toBag should equal(
+    g.nodes("n").collect.toBag should equal(
       Bag(
         Row(7L, true, "Alice", "US"),
         Row(8L, true, "Bob", "US"),
@@ -419,7 +419,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
         .withNodePropertyKeys("Person")("name" -> CTString, "region" -> CTString)
         .withRelationshipType("ACQUAINTED"))
 
-    g.nodes("n").iterator.toBag should equal(
+    g.nodes("n").collect.toBag should equal(
       Bag(
         Row(13L, true, "Mallory", "EU"),
         Row(14L, true, "Trudy", "EU"),
@@ -449,7 +449,7 @@ class GCDemoTest extends CAPSTestSuite with SparkSessionFixture with Neo4jServer
         .withNodePropertyKeys("Person")("name" -> CTString, "region" -> CTString)
         .withRelationshipType("ACQUAINTED"))
 
-    g.nodes("n").iterator.toBag should equal(
+    g.nodes("n").collect.toBag should equal(
       Bag(
         Row(7L, true, "Alice", "US"),
         Row(8L, true, "Bob", "US"),

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSPatternGraphTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSPatternGraphTest.scala
@@ -43,7 +43,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
         |RETURN GRAPH result OF (a)
       """.stripMargin)
 
-    person.graphs("result").cypher("MATCH (n) RETURN n.name").records.iterator.toSet should equal(
+    person.graphs("result").cypher("MATCH (n) RETURN n.name").records.collect.toSet should equal(
       Set(
         CypherMap("n.name" -> "Mats")
       ))
@@ -57,7 +57,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
         |RETURN GRAPH result OF (a)-[r]->(b)
       """.stripMargin)
 
-    person.graphs("result").cypher("MATCH (n) RETURN n.name").records.iterator.toSet should equal(
+    person.graphs("result").cypher("MATCH (n) RETURN n.name").records.collect.toSet should equal(
       Set(
         CypherMap("n.name" -> "Mats"),
         CypherMap("n.name" -> "Stefan"),
@@ -79,7 +79,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
       .graphs("result")
       .cypher("MATCH ()-[:SWEDISH_KNOWS]->(n) RETURN n.name")
       .records
-      .iterator
+      .collect
       .toSet should equal(
       Set(
         CypherMap("n.name" -> "Stefan"),
@@ -102,7 +102,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
       .graphs("result")
       .cypher("MATCH (b)-[:KNOWS_A]->(n) WITH COUNT(n) as cnt RETURN cnt")
       .records
-      .iterator
+      .collect
       .toSet should equal(
       Set(
         CypherMap("cnt" -> 3)
@@ -149,7 +149,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
 
     val graph = person.graphs("result")
 
-    graph.cypher("MATCH (n:Swede) RETURN labels(n)").records.iterator.toSet should equal(
+    graph.cypher("MATCH (n:Swede) RETURN labels(n)").records.collect.toSet should equal(
       Set(
         CypherMap("labels(n)" -> List("Swede")),
         CypherMap("labels(n)" -> List("Swede")),
@@ -306,7 +306,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
   test("Supports .cypher node scans") {
     val patternGraph = initPersonReadsBookGraph
 
-    patternGraph.cypher("MATCH (p:Person {name: 'Mats'}) RETURN p.luckyNumber").records.iterator.toBag should equal(
+    patternGraph.cypher("MATCH (p:Person {name: 'Mats'}) RETURN p.luckyNumber").records.collect.toBag should equal(
       Bag(CypherMap("p.luckyNumber" -> 23)))
   }
 
@@ -333,7 +333,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
 
     val patternGraph = CAPSGraph.create(CAPSRecords.verifyAndCreate(header, df), schema)
 
-    patternGraph.nodes("n", CTNode("Person")).iterator.toBag should equal(
+    patternGraph.nodes("n", CTNode("Person")).collect.toBag should equal(
       Bag(
         CypherMap("n" -> CAPSNode(0L, Set())),
         CypherMap("n" -> CAPSNode(1L, Set("Person"))),
@@ -414,7 +414,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
 
     val patternGraph = CAPSGraph.create(CAPSRecords.verifyAndCreate(header, df), schema)
 
-    patternGraph.nodes("n", CTNode).iterator.toBag should equal(
+    patternGraph.nodes("n", CTNode).collect.toBag should equal(
       Bag(
         CypherMap("n" -> CAPSNode(0L, Set("Person"), CypherMap("name" -> "PersonPeter"))))
     )
@@ -447,7 +447,7 @@ class CAPSPatternGraphTest extends CAPSTestSuite with GraphCreationFixture {
 
     val patternGraph = CAPSGraph.create(CAPSRecords.verifyAndCreate(header, df), schema)
 
-    patternGraph.nodes("n", CTNode).iterator.toBag should equal(
+    patternGraph.nodes("n", CTNode).collect.toBag should equal(
       Bag(
         CypherMap("n" -> CAPSNode(0L, Set("Person"), CypherMap("name" -> "PersonPeter"))),
         CypherMap("n" -> CAPSNode(1L, Set("Employee"), CypherMap("name" -> "EmployeePeter"))),

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsAcceptanceTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsAcceptanceTest.scala
@@ -36,7 +36,7 @@ class CAPSRecordsAcceptanceTest extends CAPSTestSuite with Neo4jServerFixture wi
     val result = graph.cypher("MATCH (a:Person) WHERE a.birthyear < 1930 RETURN a, a.name")
 
     // Then
-    val strings = result.records.iterator.map(_.toCypherString).toSet
+    val strings = result.records.collect.map(_.toCypherString).toSet
 
     // We do string comparisons here because CypherNode.equals() does not check labels/properties
     strings should equal(

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSRecordsTest.scala
@@ -171,7 +171,7 @@ class CAPSRecordsTest extends CAPSTestSuite with GraphCreationFixture with TeamD
 
     val result = g.cypher("MATCH (n) WITH 5 - n.p + 1 AS b, n RETURN n, b")
 
-    result.records.iterator.toBag should equal(
+    result.records.collect.toBag should equal(
       Bag(
         CypherMap(
           "n" -> CAPSNode(0L, Set("Foo"), CypherMap("p" -> 1)),

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSSessionImplTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/CAPSSessionImplTest.scala
@@ -35,7 +35,7 @@ class CAPSSessionImplTest extends CAPSTestSuite with TeamDataFixture {
         |INNER JOIN people p2 ON knows.dst = p2.id
       """.stripMargin)
 
-    sqlResult.iterator.toBag should equal(Bag(
+    sqlResult.collect.toBag should equal(Bag(
       CypherMap("me" -> "Mats", "since" -> 2017, "you" -> "Martin"),
       CypherMap("me" -> "Mats", "since" -> 2016, "you" -> "Max"),
       CypherMap("me" -> "Mats", "since" -> 2015, "you" -> "Stefan"),

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/AggregationBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/AggregationBehaviour.scala
@@ -32,7 +32,7 @@ trait AggregationBehaviour {
 
         val result = graph.cypher("MATCH (n) WITH AVG(n.val) AS res RETURN res")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("res" -> 4)
         ))
       }
@@ -42,7 +42,7 @@ trait AggregationBehaviour {
 
         val result = graph.cypher("MATCH (n) RETURN AVG(n.val) AS res")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("res" -> 4)
         ))
       }

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/FunctionsBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/FunctionsBehaviour.scala
@@ -298,7 +298,7 @@ trait FunctionsBehaviour {
 
         val result = given.cypher("MATCH (n) RETURN coalesce(n.valA, n.valB, n.valC) as value")
 
-        result.records.iterator.toBag should equal(
+        result.records.collect.toBag should equal(
           Bag(
             CypherMap("value" -> 1),
             CypherMap("value" -> 2),
@@ -312,7 +312,7 @@ trait FunctionsBehaviour {
 
         val result = given.cypher("MATCH (n) RETURN coalesce(n.valD, n.valE) as value")
 
-        result.records.iterator.toBag should equal(
+        result.records.collect.toBag should equal(
           Bag(
             CypherMap("value" -> null),
             CypherMap("value" -> null),

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/MatchBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/MatchBehaviour.scala
@@ -199,7 +199,7 @@ trait MatchBehaviour {
             |RETURN a.val, c.val
           """.stripMargin
 
-        graph.cypher(query).records.iterator.toBag should equal(Bag(
+        graph.cypher(query).records.collect.toBag should equal(Bag(
           CypherMap("a.val" -> 0, "c.val" -> 2)
         ))
       }
@@ -221,7 +221,7 @@ trait MatchBehaviour {
 
         val result = given.cypher("MATCH (a:A)--(other) RETURN a.prop, other.prop")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a.prop" -> "isA", "other.prop" -> "fromA"),
           CypherMap("a.prop" -> "isA", "other.prop" -> "toA")
         ))
@@ -243,7 +243,7 @@ trait MatchBehaviour {
 
         val result = given.cypher("MATCH (a:A)--()--(other) RETURN a.prop, other.prop")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a.prop" -> "a", "other.prop" -> "c"),
           CypherMap("a.prop" -> "a", "other.prop" -> "b"),
           CypherMap("a.prop" -> "a", "other.prop" -> "d")
@@ -268,7 +268,7 @@ trait MatchBehaviour {
             |RETURN a.prop, b.prop
           """.stripMargin)
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a.prop" -> "a", "b.prop" -> "b"),
           CypherMap("a.prop" -> "a", "b.prop" -> "b")
         ))
@@ -289,7 +289,7 @@ trait MatchBehaviour {
 
         val result = given.cypher("MATCH (a:A)--(a)<--(other) RETURN a.prop, other.prop")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a.prop" -> "a", "other.prop" -> "a"),
           CypherMap("a.prop" -> "a", "other.prop" -> "a"),
           CypherMap("a.prop" -> "a", "other.prop" -> "b"),
@@ -309,7 +309,7 @@ trait MatchBehaviour {
 
         val result = given.cypher("MATCH (a:A)--(a) RETURN a.prop")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a.prop" -> "isA")
         ))
       }
@@ -327,7 +327,7 @@ trait MatchBehaviour {
 
         val result = given.cypher("MATCH (a:A)-[*2..2]-(other) RETURN a.prop, other.prop")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a.prop" -> "a", "other.prop" -> "c")
         ))
       }

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/OptionalMatchBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/OptionalMatchBehaviour.scala
@@ -239,7 +239,7 @@ trait OptionalMatchBehaviour { this: AcceptanceTest =>
           |RETURN b,c
         """.stripMargin)
 
-      result.records.iterator.toBag should equal(Bag(
+      result.records.collect.toBag should equal(Bag(
         CypherMap("b" -> CypherNull, "c" -> CypherNull)
       ))
     }

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/PredicateBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/PredicateBehaviour.scala
@@ -174,7 +174,7 @@ trait PredicateBehaviour {
         val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val < b.val RETURN a.val")
 
         // Then
-        result.records.iterator.toBag shouldBe empty
+        result.records.collect.toBag shouldBe empty
 
         // And
         result.graphs shouldBe empty
@@ -209,7 +209,7 @@ trait PredicateBehaviour {
         val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val <= b.val RETURN a.val")
 
         // Then
-        result.records.iterator.toBag shouldBe empty
+        result.records.collect.toBag shouldBe empty
 
         // And
         result.graphs shouldBe empty
@@ -240,7 +240,7 @@ trait PredicateBehaviour {
         val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val > b.val RETURN a.val")
 
         // Then
-        result.records.iterator.toBag shouldBe empty
+        result.records.collect.toBag shouldBe empty
 
         // And
         result.graphs shouldBe empty
@@ -272,7 +272,7 @@ trait PredicateBehaviour {
         val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val >= b.val RETURN a.val")
 
         // Then
-        result.records.iterator.toBag shouldBe empty
+        result.records.collect.toBag shouldBe empty
 
         // And
         result.graphs shouldBe empty
@@ -289,7 +289,7 @@ trait PredicateBehaviour {
           |RETURN a.val
         """.stripMargin
 
-      graph.cypher(query).records.iterator.toBag should equal(Bag(
+      graph.cypher(query).records.collect.toBag should equal(Bag(
         CypherMap("a.val" -> 10)
       ))
     }

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/ReturnBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/ReturnBehaviour.scala
@@ -32,7 +32,7 @@ trait ReturnBehaviour {
 
         val result = g.cypher("MATCH (a:A) WITH a, a.name AS foo RETURN a")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a" -> CAPSNode(0L, Set("A"), CypherMap("name" -> "me"))),
           CypherMap("a" -> CAPSNode(1L, Set("A"), CypherMap.empty))
         ))
@@ -43,7 +43,7 @@ trait ReturnBehaviour {
 
         val result = g.cypher("MATCH (a:A) WITH a, a AS foo RETURN a")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a" -> CAPSNode(0L, Set("A"), CypherMap("name" -> "me"))),
           CypherMap("a" -> CAPSNode(1L, Set("A"), CypherMap.empty))
         ))
@@ -56,7 +56,7 @@ trait ReturnBehaviour {
         // perhaps copy all child expressions in RecordHeader
         val result = g.cypher("MATCH (a:A) WITH a, a AS foo RETURN foo AS b")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a" -> CAPSNode(0L, Set("A"), CypherMap("name" -> "me"))),
           CypherMap("a" -> CAPSNode(1L, Set("A"), CypherMap.empty))
         ))
@@ -67,7 +67,7 @@ trait ReturnBehaviour {
 
         val result = g.cypher("MATCH (a:A), (b) RETURN a")
 
-        result.records.iterator.toBag should equal(Bag(
+        result.records.collect.toBag should equal(Bag(
           CypherMap("a" -> CAPSNode(0L, Set("A"), CypherMap.empty))
         ))
       }
@@ -155,7 +155,7 @@ trait ReturnBehaviour {
           """.stripMargin
 
 
-        graph.cypher(query).records.iterator.toBag should equal(Bag(
+        graph.cypher(query).records.collect.toBag should equal(Bag(
           CypherMap("a.val" -> 0)
         ))
       }

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/WithBehaviour.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/spark/acceptance/WithBehaviour.scala
@@ -194,7 +194,7 @@ trait WithBehaviour { this: AcceptanceTest =>
           |RETURN val1, val2, val3
         """.stripMargin)
 
-      result.records.iterator.toBag should equal(Bag(
+      result.records.collect.toBag should equal(Bag(
         CypherMap("val1" -> 1, "val2" -> 3, "val3" -> 10)
       ))
     }

--- a/caps-spark/src/test/scala/org/opencypher/caps/impl/table/EntityTableTest.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/impl/table/EntityTableTest.scala
@@ -91,7 +91,7 @@ class EntityTableTest extends CAPSTestSuite {
     val nodeTable = CAPSNodeTable(nodeMapping, df)
 
     val graph = CAPSGraph.create(nodeTable)
-    graph.nodes("n").iterator.toSet {
+    graph.nodes("n").collect.toSet {
       CypherMap("n" -> "1")
     }
   }

--- a/caps-spark/src/test/scala/org/opencypher/caps/test/support/RecordMatchingTestSupport.scala
+++ b/caps-spark/src/test/scala/org/opencypher/caps/test/support/RecordMatchingTestSupport.scala
@@ -36,7 +36,7 @@ trait RecordMatchingTestSupport {
 
   implicit class RecordMatcher(records: CAPSRecords) {
     def shouldMatch(expected: CypherMap*): Assertion = {
-      records.iterator.toBag should equal(Bag(expected: _*))
+      records.collect.toBag should equal(Bag(expected: _*))
     }
 
     def shouldMatch(expectedRecords: CAPSRecords): Assertion = {

--- a/caps-tck/src/test/scala/org/opencypher/caps/tck/TCKFixture.scala
+++ b/caps-tck/src/test/scala/org/opencypher/caps/tck/TCKFixture.scala
@@ -90,7 +90,7 @@ case class TCKGraph[C <: CypherSession](testGraphFactory: TestGraphFactory[C], g
 
   private def convertToTckStrings(records: CypherRecords): StringRecords = {
     val header = records.columns.toList
-    val rows: List[Map[String, String]] = records.iterator.map { cypherMap: CAPSCypherMap =>
+    val rows: List[Map[String, String]] = records.collect.map { cypherMap: CAPSCypherMap =>
       cypherMap.keys.map(k => k -> cypherMap(k).toCypherString).toMap
     }.toList
     StringRecords(header, rows)


### PR DESCRIPTION
During the benchmarks we found that `DataFrame.toLocalIterator` often is considerably slower than `collect`. This PR introduces collect on the public CypherRecord interfaces and uses the where possible