### PR TITLE
Physical operator refactoring

### DIFF
--- a/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/LogicalPlanner.scala
+++ b/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/LogicalPlanner.scala
@@ -414,7 +414,7 @@ class LogicalPlanner(producer: LogicalOperatorProducer)
           val (leftIn, rightIn) = joinPredicates.foldLeft((lhs, rhs)) {
             case ((l, r), predicate) => producer.projectExpr(predicate.lhs, l) -> producer.projectExpr(predicate.rhs, r)
           }
-          producer.planValueJoin(leftIn, rightIn, joinPredicates.toSet)
+          producer.planValueJoin(leftIn, rightIn, joinPredicates)
         }
       }
       // TODO: use type system to avoid empty pattern

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/configuration/CoraConfiguration.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/configuration/CoraConfiguration.scala
@@ -34,6 +34,8 @@ object CoraConfiguration {
 
   object PrintPhysicalPlan extends ConfigFlag("cora.explainPhysical", false)
 
+  object PrintOptimizedPhysicalPlan extends ConfigFlag("cora.explainOptimizedPhysical", false)
+
   object DebugPhysicalResult extends ConfigFlag("cora.debugPhysical", false)
 
   object PrintQueryExecutionStages extends ConfigFlag("cora.stages", false)

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
@@ -258,6 +258,17 @@ trait PhysicalOperatorProducer[P <: PhysicalOperator[R, G, C], R <: CypherRecord
   def planCartesianProduct(lhs: P, rhs: P, header: RecordHeader): P
 
   /**
+    * Joins the two input records on given variables.
+    *
+    * @param lhs         first previous operator
+    * @param rhs         second previous operator
+    * @param joinColumns sequence of left and right join columns
+    * @param header      resulting record header
+    * @return join operator
+    */
+  def planJoin(lhs: P, rhs: P, joinColumns: Seq[(Expr, Expr)], header: RecordHeader): P
+
+  /**
     * Joins the two input records on node attribute values.
     *
     * @param lhs        first previous operator
@@ -374,7 +385,7 @@ trait PhysicalOperatorProducer[P <: PhysicalOperator[R, G, C], R <: CypherRecord
   /**
     * Performs a UNION ALL over graphs.
     *
-    * @param graphs graph to perform UNION ALL over
+    * @param graphs              graph to perform UNION ALL over
     * @param preventIdCollisions flag that indicates if ID collisions between entities should be prevented
     * @return union all operator
     */

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
@@ -27,11 +27,9 @@
 package org.opencypher.okapi.relational.api.physical
 
 import org.opencypher.okapi.api.graph.{PropertyGraph, QualifiedGraphName}
-import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.api.table.CypherRecords
 import org.opencypher.okapi.ir.api.block.SortItem
 import org.opencypher.okapi.ir.api.expr.{Aggregator, Expr, Var}
-import org.opencypher.okapi.ir.api.set.SetPropertyItem
 import org.opencypher.okapi.logical.impl._
 import org.opencypher.okapi.relational.impl.table.{ProjectedExpr, ProjectedField, RecordHeader}
 
@@ -258,7 +256,7 @@ trait PhysicalOperatorProducer[P <: PhysicalOperator[R, G, C], R <: CypherRecord
   def planCartesianProduct(lhs: P, rhs: P, header: RecordHeader): P
 
   /**
-    * Joins the two input records on given variables.
+    * Joins the two input records using the given expressions.
     *
     * @param lhs         first previous operator
     * @param rhs         second previous operator
@@ -325,30 +323,6 @@ trait PhysicalOperatorProducer[P <: PhysicalOperator[R, G, C], R <: CypherRecord
   def planExistsSubQuery(lhs: P, rhs: P, targetField: Var, header: RecordHeader): P
 
   // Ternary operators
-
-  /**
-    * Expands the records in the first input (nodes) via the records in the second input (relationships) into the
-    * records in the third input (nodes).
-    *
-    * @param first                   first previous operator
-    * @param second                  second previous operator
-    * @param third                   third previous operator
-    * @param source                  node variable in the first input
-    * @param rel                     relationship variable in the second input
-    * @param target                  node variable in the third input
-    * @param header                  resulting record header
-    * @param removeSelfRelationships set true, iff loops shall be removed from the output
-    * @return expand source operator
-    */
-  def planExpandSource(
-    first: P,
-    second: P,
-    third: P,
-    source: Var,
-    rel: Var,
-    target: Var,
-    header: RecordHeader,
-    removeSelfRelationships: Boolean = false): P
 
   /**
     * Performs a bounded variable length path expression.

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
@@ -267,17 +267,6 @@ trait PhysicalOperatorProducer[P <: PhysicalOperator[R, G, C], R <: CypherRecord
   def planJoin(lhs: P, rhs: P, joinColumns: Seq[(Expr, Expr)], header: RecordHeader): P
 
   /**
-    * Joins the two input records on node attribute values.
-    *
-    * @param lhs        first previous operator
-    * @param rhs        second previous operator
-    * @param predicates join predicates
-    * @param header     resulting record header
-    * @return value join operator
-    */
-  def planValueJoin(lhs: P, rhs: P, predicates: Set[org.opencypher.okapi.ir.api.expr.Equals], header: RecordHeader): P
-
-  /**
     * Unions the input records.
     *
     * @param lhs first previous operator

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/physical/PhysicalOperatorProducer.scala
@@ -287,20 +287,6 @@ trait PhysicalOperatorProducer[P <: PhysicalOperator[R, G, C], R <: CypherRecord
   def planTabularUnionAll(lhs: P, rhs: P): P
 
   /**
-    * Joins the two input records on two columns, where `source` is solved in the first operator and `target` is solved
-    * in the second operator.
-    *
-    * @param lhs    first previous operator
-    * @param rhs    second previous operator
-    * @param source variable solved by the first operator
-    * @param rel    relationship variable
-    * @param target variable solved by the second operator
-    * @param header resulting record header
-    * @return expand into operator
-    */
-  def planExpandInto(lhs: P, rhs: P, source: Var, rel: Var, target: Var, header: RecordHeader): P
-
-  /**
     * Computes the result of an OPTIONAL MATCH where the first input is the non-optional part and the second input the
     * optional one.
     *

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
@@ -166,8 +166,8 @@ class PhysicalPlanner[P <: PhysicalOperator[R, G, C], R <: CypherRecords, G <: P
         val in = process(sourceOp)
         val relationships = producer.planRelationshipScan(in, op.sourceGraph, rel, relHeader)
 
-        val startNode = StartNode(rel)(CTNode)
-        val endNode = EndNode(rel)(CTNode)
+        val startNode = StartNode(rel)()
+        val endNode = EndNode(rel)()
 
         direction match {
           case Directed =>

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
@@ -28,10 +28,10 @@ package org.opencypher.okapi.relational.impl.physical
 
 import org.opencypher.okapi.api.graph.{CypherSession, PropertyGraph, QualifiedGraphName}
 import org.opencypher.okapi.api.table.CypherRecords
-import org.opencypher.okapi.api.types.CTRelationship
+import org.opencypher.okapi.api.types.{CTNode, CTRelationship}
 import org.opencypher.okapi.impl.exception.{IllegalArgumentException, NotImplementedException}
 import org.opencypher.okapi.ir.api.block.SortItem
-import org.opencypher.okapi.ir.api.expr.{Expr, TrueLit, Var}
+import org.opencypher.okapi.ir.api.expr._
 import org.opencypher.okapi.ir.api.util.DirectCompilationStage
 import org.opencypher.okapi.logical.impl._
 import org.opencypher.okapi.relational.api.physical.{PhysicalOperator, PhysicalOperatorProducer, PhysicalPlannerContext, RuntimeContext}
@@ -144,7 +144,9 @@ class PhysicalPlanner[P <: PhysicalOperator[R, G, C], R <: CypherRecords, G <: P
 
         direction match {
           case Directed =>
-            producer.planExpandSource(first, second, third, source, rel, target, header)
+            val tempResult = producer.planJoin(first, second, Seq(source -> StartNode(rel)(CTNode)), first.header ++ second.header)
+            producer.planJoin(tempResult, third, Seq(EndNode(rel)(CTNode) -> target), header)
+
           case Undirected =>
             val outgoing = producer.planExpandSource(first, second, third, source, rel, target, header)
             val incoming = producer.planExpandSource(third, second, first, target, rel, source, header, removeSelfRelationships = true)

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
@@ -122,7 +122,8 @@ class PhysicalPlanner[P <: PhysicalOperator[R, G, C], R <: CypherRecords, G <: P
         }
 
       case flat.ValueJoin(lhs, rhs, predicates, header) =>
-        producer.planValueJoin(process(lhs), process(rhs), predicates, header)
+        val joinExpressions = predicates.map(p => p.lhs -> p.rhs).toSeq
+        producer.planJoin(process(lhs), process(rhs), joinExpressions, header)
 
       case flat.Distinct(fields, in, _) =>
         producer.planDistinct(process(in), fields)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSSessionImpl.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSSessionImpl.scala
@@ -43,7 +43,7 @@ import org.opencypher.okapi.ir.impl.parse.CypherParser
 import org.opencypher.okapi.ir.impl.{IRBuilder, IRBuilderContext}
 import org.opencypher.okapi.logical.api.configuration.LogicalConfiguration.PrintLogicalPlan
 import org.opencypher.okapi.logical.impl._
-import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.{PrintFlatPlan, PrintPhysicalPlan, PrintQueryExecutionStages}
+import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.{PrintFlatPlan, PrintOptimizedPhysicalPlan, PrintPhysicalPlan, PrintQueryExecutionStages}
 import org.opencypher.okapi.relational.impl.flat.{FlatPlanner, FlatPlannerContext}
 import org.opencypher.okapi.relational.impl.physical.PhysicalPlanner
 import org.opencypher.spark.api.CAPSSession
@@ -235,7 +235,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession, val sessionNamespac
     logStageProgress("Physical optimization ... ", newLine = false)
     val optimizedPhysicalPlan = time("Physical optimization")(physicalOptimizer(physicalPlan)(PhysicalOptimizerContext()))
     logStageProgress("Done!")
-    if (PrintPhysicalPlan.isSet) {
+    if (PrintOptimizedPhysicalPlan.isSet) {
       println("Optimized physical plan:")
       println(optimizedPhysicalPlan.pretty())
     }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/DataFrameOps.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/DataFrameOps.scala
@@ -198,7 +198,7 @@ object DataFrameOps {
 
       val joinExpr = joinCols.map {
         case (l, r) => df.col(l) === other.col(r)
-      }.foldLeft(lit(true))((acc, expr) => acc && expr)
+      }.reduce((acc, expr) => acc && expr)
 
       df.join(other, joinExpr, joinType)
     }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
@@ -122,12 +122,6 @@ final class CAPSPhysicalOperatorProducer(implicit caps: CAPSSession)
     joinColumns: Seq[(Expr, Expr)],
     header: RecordHeader): CAPSPhysicalOperator = operators.Join(lhs, rhs, joinColumns, header)
 
-  override def planValueJoin(
-    lhs: CAPSPhysicalOperator,
-    rhs: CAPSPhysicalOperator,
-    predicates: Set[Equals],
-    header: RecordHeader): CAPSPhysicalOperator = operators.ValueJoin(lhs, rhs, predicates, header)
-
   override def planDistinct(in: CAPSPhysicalOperator, fields: Set[Var]): CAPSPhysicalOperator =
     operators.Distinct(in, fields)
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
@@ -134,14 +134,6 @@ final class CAPSPhysicalOperatorProducer(implicit caps: CAPSSession)
   override def planTabularUnionAll(lhs: CAPSPhysicalOperator, rhs: CAPSPhysicalOperator): CAPSPhysicalOperator =
     operators.TabularUnionAll(lhs, rhs)
 
-  override def planExpandInto(
-    lhs: CAPSPhysicalOperator,
-    rhs: CAPSPhysicalOperator,
-    source: Var,
-    rel: Var,
-    target: Var,
-    header: RecordHeader): CAPSPhysicalOperator = operators.ExpandInto(lhs, rhs, source, rel, target, header)
-
   override def planInitVarExpand(
     in: CAPSPhysicalOperator,
     source: Var,

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
@@ -131,17 +131,6 @@ final class CAPSPhysicalOperatorProducer(implicit caps: CAPSSession)
   override def planDistinct(in: CAPSPhysicalOperator, fields: Set[Var]): CAPSPhysicalOperator =
     operators.Distinct(in, fields)
 
-  override def planExpandSource(
-    first: CAPSPhysicalOperator,
-    second: CAPSPhysicalOperator,
-    third: CAPSPhysicalOperator,
-    source: Var,
-    rel: Var,
-    target: Var,
-    header: RecordHeader,
-    removeSelfRelationships: Boolean): CAPSPhysicalOperator = operators.ExpandSource(
-    first, second, third, source, rel, target, header, removeSelfRelationships)
-
   override def planTabularUnionAll(lhs: CAPSPhysicalOperator, rhs: CAPSPhysicalOperator): CAPSPhysicalOperator =
     operators.TabularUnionAll(lhs, rhs)
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
@@ -87,13 +87,13 @@ final class CAPSPhysicalOperatorProducer(implicit caps: CAPSSession)
     in: CAPSPhysicalOperator,
     inGraph: LogicalGraph,
     v: Var,
-    header: RecordHeader): CAPSPhysicalOperator = operators.Scan(in, v, header)
+    header: RecordHeader): CAPSPhysicalOperator = operators.NodeScan(in, v, header)
 
   override def planRelationshipScan(
     in: CAPSPhysicalOperator,
     inGraph: LogicalGraph,
     v: Var,
-    header: RecordHeader): CAPSPhysicalOperator = operators.Scan(in, v, header)
+    header: RecordHeader): CAPSPhysicalOperator = operators.RelationshipScan(in, v, header)
 
   override def planAlias(in: CAPSPhysicalOperator, expr: Expr, alias: Var, header: RecordHeader): CAPSPhysicalOperator =
     operators.Alias(in, expr, alias, header)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/CAPSPhysicalOperatorProducer.scala
@@ -116,6 +116,12 @@ final class CAPSPhysicalOperatorProducer(implicit caps: CAPSSession)
   override def planFilter(in: CAPSPhysicalOperator, expr: Expr, header: RecordHeader): CAPSPhysicalOperator =
     operators.Filter(in, expr, header)
 
+  override def planJoin(
+    lhs: CAPSPhysicalOperator,
+    rhs: CAPSPhysicalOperator,
+    joinColumns: Seq[(Expr, Expr)],
+    header: RecordHeader): CAPSPhysicalOperator = operators.Join(lhs, rhs, joinColumns, header)
+
   override def planValueJoin(
     lhs: CAPSPhysicalOperator,
     rhs: CAPSPhysicalOperator,

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
@@ -246,30 +246,10 @@ final case class CartesianProduct(lhs: CAPSPhysicalOperator, rhs: CAPSPhysicalOp
 
   override def executeBinary(left: CAPSPhysicalResult, right: CAPSPhysicalResult)(
     implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
-//    println("cross")
-//    println("header")
-//    println(header.pretty)
 
     val data = left.records.data
-//    println("left struct type")
-//    println(left.records.data.schema)
-//    println()
-//    println("left data")
-//    left.records.data.show()
-//    println()
-//    println("right struct type")
-//    println(right.records.data.schema)
-//    println()
-//    println("right data")
-//    right.records.data.show()
-//    println()
-
     val otherData = right.records.data
     val newData = data.crossJoin(otherData)
-//    println("cross struct type")
-//    println(newData.schema)
-//    println("cross data")
-//    newData.show()
 
     val records = CAPSRecords.verifyAndCreate(header, newData)(left.records.caps)
     CAPSPhysicalResult(records, left.graph)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
@@ -73,25 +73,6 @@ final case class Join(
   }
 }
 
-final case class ValueJoin(
-  lhs: CAPSPhysicalOperator,
-  rhs: CAPSPhysicalOperator,
-  predicates: Set[org.opencypher.okapi.ir.api.expr.Equals],
-  header: RecordHeader)
-  extends BinaryPhysicalOperator {
-
-  override def executeBinary(left: CAPSPhysicalResult, right: CAPSPhysicalResult)(
-    implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
-    val leftHeader = left.records.header
-    val rightHeader = right.records.header
-    val slots = predicates.map { p =>
-      leftHeader.slotsFor(p.lhs).head -> rightHeader.slotsFor(p.rhs).head
-    }.toSeq
-
-    CAPSPhysicalResult(joinRecords(header, slots)(left.records, right.records), left.graph)
-  }
-}
-
 /**
   * This operator performs a left outer join between the already matched path and the optional matched pattern and
   * updates the resulting columns.
@@ -265,30 +246,30 @@ final case class CartesianProduct(lhs: CAPSPhysicalOperator, rhs: CAPSPhysicalOp
 
   override def executeBinary(left: CAPSPhysicalResult, right: CAPSPhysicalResult)(
     implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
-    println("cross")
-    println("header")
-    println(header.pretty)
+//    println("cross")
+//    println("header")
+//    println(header.pretty)
 
     val data = left.records.data
-    println("left struct type")
-    println(left.records.data.schema)
-    println()
-    println("left data")
-    left.records.data.show()
-    println()
-    println("right struct type")
-    println(right.records.data.schema)
-    println()
-    println("right data")
-    right.records.data.show()
-    println()
+//    println("left struct type")
+//    println(left.records.data.schema)
+//    println()
+//    println("left data")
+//    left.records.data.show()
+//    println()
+//    println("right struct type")
+//    println(right.records.data.schema)
+//    println()
+//    println("right data")
+//    right.records.data.show()
+//    println()
 
     val otherData = right.records.data
     val newData = data.crossJoin(otherData)
-    println("cross struct type")
-    println(newData.schema)
-    println("cross data")
-    newData.show()
+//    println("cross struct type")
+//    println(newData.schema)
+//    println("cross data")
+//    newData.show()
 
     val records = CAPSRecords.verifyAndCreate(header, newData)(left.records.caps)
     CAPSPhysicalResult(records, left.graph)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
@@ -239,35 +239,6 @@ final case class ExistsSubQuery(
   }
 }
 
-// This maps a Cypher pattern such as (s)-[r]->(t), where s and t are both solved by lhs, and r is solved by rhs
-final case class ExpandInto(
-  lhs: CAPSPhysicalOperator,
-  rhs: CAPSPhysicalOperator,
-  source: Var,
-  rel: Var,
-  target: Var,
-  header: RecordHeader)
-  extends BinaryPhysicalOperator {
-
-  override def executeBinary(left: CAPSPhysicalResult, right: CAPSPhysicalResult)(
-    implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
-    val sourceSlot = left.records.header.slotFor(source)
-    val targetSlot = left.records.header.slotFor(target)
-    val relSourceSlot = right.records.header.sourceNodeSlot(rel)
-    val relTargetSlot = right.records.header.targetNodeSlot(rel)
-
-    assertIsNode(sourceSlot)
-    assertIsNode(targetSlot)
-    assertIsNode(relSourceSlot)
-    assertIsNode(relTargetSlot)
-
-    val joinedRecords =
-      joinRecords(header, Seq(sourceSlot -> relSourceSlot, targetSlot -> relTargetSlot))(left.records, right.records)
-    CAPSPhysicalResult(joinedRecords, left.graph)
-  }
-
-}
-
 /**
   * Computes the union of the two input operators. The two inputs must have identical headers.
   * This operation does not remove duplicates.

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/CAPSPhysicalOperator.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/CAPSPhysicalOperator.scala
@@ -76,8 +76,8 @@ object CAPSPhysicalOperator {
     // TODO: the join produced corrupt data when the previous operator was a cross. We work around that by using a
     // subsequent select. This can be removed, once https://issues.apache.org/jira/browse/SPARK-23855 is solved or we
     // upgrade to Spark 2.3.0
-    val weirdResult = joinDFs(lhsData, rhsData, header, joinCols)(joinType, deduplicate)(lhs.caps)
-    val select = weirdResult.data.select("*")
+    val potentiallyCorruptedResult = joinDFs(lhsData, rhsData, header, joinCols)(joinType, deduplicate)(lhs.caps)
+    val select = potentiallyCorruptedResult.data.select("*")
     CAPSRecords.verifyAndCreate(header, select)(lhs.caps)
   }
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/CAPSPhysicalOperator.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/CAPSPhysicalOperator.scala
@@ -73,7 +73,50 @@ object CAPSPhysicalOperator {
 
     val joinCols = joinSlots.map(pair => columnName(pair._1) -> columnName(pair._2))
 
-    joinDFs(lhsData, rhsData, header, joinCols)(joinType, deduplicate)(lhs.caps)
+//    println("join")
+//    println("record header")
+//    println(header.pretty)
+//
+//
+//    println("join columns")
+//    println(joinCols)
+//    println()
+//    println("left struct type")
+//    println(lhsData.schema)
+//    println()
+//    println("left data")
+//    lhsData.show
+//    println()
+//    println("right struct type")
+//    println(rhsData.schema)
+//    println()
+//    println("right data")
+//    rhsData.show
+
+    val weirdResult = joinDFs(lhsData, rhsData, header, joinCols)(joinType, deduplicate)(lhs.caps)
+//
+//    println()
+//    println("weirdResult struct type")
+//    println(weirdResult.data.schema)
+//    println("weirdResult data")
+//    weirdResult.data.show
+
+    val selectColumns = header.slots
+      .map(ColumnName.of)
+      .map(weirdResult.data.col)
+
+//    println("select columns")
+//    println(selectColumns)
+//    println("existing columns")
+//    println(weirdResult.data.columns.toList)
+
+    val select = weirdResult.data.select(selectColumns: _*)
+    val result = CAPSRecords.verifyAndCreate(header, select)(lhs.caps)
+
+//    println(weirdResult.data.schema)
+//    println(result.data.schema)
+
+    result
   }
 
   def joinDFs(lhsData: DataFrame, rhsData: DataFrame, header: RecordHeader, joinCols: Seq[(String, String)])(

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/UnaryOperators.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/UnaryOperators.scala
@@ -189,16 +189,7 @@ final case class Filter(in: CAPSPhysicalOperator, expr: Expr, header: RecordHead
   override def executeUnary(prev: CAPSPhysicalResult)(implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
     prev.mapRecordsWithDetails { records =>
       val filteredRows = records.data.where(expr.asSparkSQLExpr(header, records.data, context))
-
-      // TODO: is this necessary? Filter should just remove rows
-      val selectedColumns = header.slots.map { c =>
-        val name = ColumnName.of(c)
-        filteredRows.col(name)
-      }
-
-      val newData = filteredRows.select(selectedColumns: _*)
-
-      CAPSRecords.verifyAndCreate(header, newData)(records.caps)
+      CAPSRecords.verifyAndCreate(header, filteredRows)(records.caps)
     }
   }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/SparkTests.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/SparkTests.scala
@@ -24,10 +24,32 @@
  * described as "implementation extensions to Cypher" or as "proposed changes to
  * Cypher that are not yet approved by the openCypher community".
  */
-package org.opencypher.spark.impl.acceptance
+package org.opencypher.spark
 
-import org.opencypher.spark.test.support.creation.caps.{CAPSScanGraphFactory, CAPSTestGraphFactory}
+import org.opencypher.spark.test.CAPSTestSuite
 
-class CAPSScanGraphAcceptanceTest extends AcceptanceTest {
-  override def capsGraphFactory: CAPSTestGraphFactory = CAPSScanGraphFactory
+class SparkTests extends CAPSTestSuite {
+
+  // Example for: https://issues.apache.org/jira/browse/SPARK-23855
+  ignore("should correctly perform a join after a cross") {
+    val df1 = sparkSession.createDataFrame(Seq(Tuple1(0L)))
+      .toDF("a")
+
+    val df2 = sparkSession.createDataFrame(Seq(Tuple1(1L)))
+      .toDF("b")
+
+    val df3 = sparkSession.createDataFrame(Seq(Tuple1(0L)))
+      .toDF("c")
+
+    val cross = df1.crossJoin(df2)
+    cross.show()
+
+    val joined = cross
+      .join(df3, cross.col("a") === df3.col("c"))
+
+    joined.show()
+
+    val selected = joined.select("*")
+    selected.show
+  }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
@@ -26,8 +26,33 @@
  */
 package org.opencypher.spark.impl.acceptance
 
+import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.{PrintFlatPlan, PrintOptimizedPhysicalPlan, PrintPhysicalPlan}
 import org.opencypher.spark.test.support.creation.caps.{CAPSScanGraphFactory, CAPSTestGraphFactory}
 
 class CAPSScanGraphAcceptanceTest extends AcceptanceTest {
   override def capsGraphFactory: CAPSTestGraphFactory = CAPSScanGraphFactory
+
+  it("foo") {
+
+//    PrintFlatPlan.set
+//    PrintPhysicalPlan.set
+//    PrintOptimizedPhysicalPlan.set
+
+    val graph = initGraph(
+      """
+        |CREATE (a {name: 'A'}), (b {name: 'B'}),
+        |       (x1 {name: 'x1'})
+        |CREATE (a)-[:KNOWS]->(x1),
+        |       (b)-[:KNOWS]->(x1)
+      """.stripMargin)
+
+    val results = graph.cypher(
+      """
+        |MATCH (a {name: 'A'}), (b {name: 'B'})
+        |MATCH (a)-[e]->(x)<-[f]->(b)
+        |RETURN x
+      """.stripMargin)
+
+    results.show
+  }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
@@ -26,8 +26,45 @@
  */
 package org.opencypher.spark.impl.acceptance
 
+import org.opencypher.okapi.api.value.CypherValue
+import org.opencypher.okapi.api.value.CypherValue.CypherMap
+import org.opencypher.okapi.ir.test.support.Bag
+import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.{PrintFlatPlan, PrintPhysicalPlan}
 import org.opencypher.spark.test.support.creation.caps.{CAPSScanGraphFactory, CAPSTestGraphFactory}
 
 class CAPSScanGraphAcceptanceTest extends AcceptanceTest {
   override def capsGraphFactory: CAPSTestGraphFactory = CAPSScanGraphFactory
+
+  it("can handle multiple match clauses") {
+
+    PrintPhysicalPlan.set
+
+    // Given
+    val given = initGraph(
+      """CREATE (p1:Person {name: "Alice"})
+        |CREATE (p2:Person {name: "Bob"})
+        |CREATE (p3:Person {name: "Eve"})
+        |CREATE (p1)-[:KNOWS]->(p2)
+        |CREATE (p2)-[:KNOWS]->(p3)
+      """.stripMargin)
+
+    // When
+    val result = given.cypher(
+      """MATCH (p1:Person)
+        |MATCH (p1:Person)-[e1]->(p2:Person)
+        |MATCH (p2)-[e2]->(p3:Person)
+        |RETURN p1.name, p2.name, p3.name
+      """.stripMargin)
+
+    // Then
+    result.getRecords.toMaps should equal(
+      Bag(
+        CypherMap(
+          "p1.name" -> "Alice",
+          "p2.name" -> "Bob",
+          "p3.name" ->
+            "Eve"
+        )
+      ))
+  }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
@@ -26,36 +26,8 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.opencypher.okapi.api.value.CypherValue.CypherMap
-import org.opencypher.okapi.ir.test.support.Bag
-import org.opencypher.okapi.ir.test.support.Bag._
-import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.PrintPhysicalPlan
 import org.opencypher.spark.test.support.creation.caps.{CAPSScanGraphFactory, CAPSTestGraphFactory}
 
 class CAPSScanGraphAcceptanceTest extends AcceptanceTest {
   override def capsGraphFactory: CAPSTestGraphFactory = CAPSScanGraphFactory
-
-  it("matches an undirected relationship") {
-
-    PrintPhysicalPlan.set
-
-    val given = initGraph(
-      """
-        |CREATE (a:A {prop: 'isA'})
-        |CREATE (b:B {prop: 'fromA'})
-        |CREATE (c:C {prop: 'toA'})
-        |CREATE (d:D)
-        |CREATE (a)-[:T]->(b)
-        |CREATE (b)-[:T]->(c)
-        |CREATE (c)-[:T]->(a)
-      """.stripMargin
-    )
-
-    val result = given.cypher("MATCH (a:A)--(other) RETURN a.prop, other.prop")
-
-    result.getRecords.collect.toBag should equal(Bag(
-      CypherMap("a.prop" -> "isA", "other.prop" -> "fromA"),
-      CypherMap("a.prop" -> "isA", "other.prop" -> "toA")
-    ))
-  }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/acceptance/CAPSScanGraphAcceptanceTest.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.{PrintFlatPlan, PrintOptimizedPhysicalPlan, PrintPhysicalPlan}
 import org.opencypher.spark.test.support.creation.caps.{CAPSScanGraphFactory, CAPSTestGraphFactory}
 
 class CAPSScanGraphAcceptanceTest extends AcceptanceTest {
@@ -54,5 +53,21 @@ class CAPSScanGraphAcceptanceTest extends AcceptanceTest {
       """.stripMargin)
 
     results.show
+  }
+
+
+  it("should correctly perform a join after a cross") {
+    val df1 = sparkSession.createDataFrame(Seq((0L, "A")))
+      .toDF("a", "____a_dot_nameSTRING")
+    val df2 = sparkSession.createDataFrame(Seq((1L, "B")))
+      .toDF("b", "____b_dot_nameSTRING")
+    val df3 = sparkSession.createDataFrame(Seq((1L, 4L, "KNOWS", 2L)))
+      .toDF("____source(e)", "e", "____type(e)", "____target(e)")
+
+    val cross = df1.crossJoin(df2)
+    cross.show()
+    val join = cross.join(df3, cross.col("b") === df3.col("____source(e)"))
+
+    join.show()
   }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/physical/PhysicalOptimizerTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/physical/PhysicalOptimizerTest.scala
@@ -27,12 +27,14 @@
 package org.opencypher.spark.impl.physical
 
 import org.opencypher.okapi.api.graph.{GraphName, Namespace, QualifiedGraphName}
+import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.api.types.CTNode
 import org.opencypher.okapi.ir.api.expr.Var
+import org.opencypher.okapi.logical.impl.LogicalCatalogGraph
 import org.opencypher.okapi.relational.impl.table.RecordHeader
 import org.opencypher.spark.impl.CAPSConverters._
-import org.opencypher.spark.impl.physical.operators.{Cache, CartesianProduct, Scan, Start}
 import org.opencypher.spark.impl.{CAPSGraph, CAPSRecords}
+import org.opencypher.spark.impl.physical.operators.{Cache, CartesianProduct, Scan, Start}
 import org.opencypher.spark.test.CAPSTestSuite
 import org.opencypher.spark.test.fixture.GraphCreationFixture
 
@@ -47,12 +49,12 @@ class PhysicalOptimizerTest extends CAPSTestSuite with GraphCreationFixture {
   test("Test insert Cache operators") {
     val plan = CartesianProduct(
       CartesianProduct(
-        Scan(
+        NodeScan(
           Start(emptyRecords, emptyGraph),
           Var("C")(CTNode),
           RecordHeader.empty
         ),
-        Scan(
+        NodeScan(
           Start(emptyRecords, emptyGraph),
           Var("B")(CTNode),
           RecordHeader.empty
@@ -60,12 +62,12 @@ class PhysicalOptimizerTest extends CAPSTestSuite with GraphCreationFixture {
         RecordHeader.empty
       ),
       CartesianProduct(
-        Scan(
+        NodeScan(
           Start(emptyRecords, emptyGraph),
           Var("C")(CTNode),
           RecordHeader.empty
         ),
-        Scan(
+        NodeScan(
           Start(emptyRecords, emptyGraph),
           Var("B")(CTNode),
           RecordHeader.empty
@@ -82,12 +84,12 @@ class PhysicalOptimizerTest extends CAPSTestSuite with GraphCreationFixture {
       CartesianProduct(
         Cache(
           CartesianProduct(
-            Scan(
+            NodeScan(
               Start(emptyRecords, emptyGraph),
               Var("C")(CTNode),
               RecordHeader.empty
             ),
-            Scan(
+            NodeScan(
               Start(emptyRecords, emptyGraph),
               Var("B")(CTNode),
               RecordHeader.empty
@@ -97,12 +99,12 @@ class PhysicalOptimizerTest extends CAPSTestSuite with GraphCreationFixture {
         ),
         Cache(
           CartesianProduct(
-            Scan(
+            NodeScan(
               Start(emptyRecords, emptyGraph),
               Var("C")(CTNode),
               RecordHeader.empty
             ),
-            Scan(
+            NodeScan(
               Start(emptyRecords, emptyGraph),
               Var("B")(CTNode),
               RecordHeader.empty

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/physical/PhysicalOptimizerTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/physical/PhysicalOptimizerTest.scala
@@ -27,14 +27,12 @@
 package org.opencypher.spark.impl.physical
 
 import org.opencypher.okapi.api.graph.{GraphName, Namespace, QualifiedGraphName}
-import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.api.types.CTNode
 import org.opencypher.okapi.ir.api.expr.Var
-import org.opencypher.okapi.logical.impl.LogicalCatalogGraph
 import org.opencypher.okapi.relational.impl.table.RecordHeader
 import org.opencypher.spark.impl.CAPSConverters._
+import org.opencypher.spark.impl.physical.operators.{Cache, CartesianProduct, NodeScan, Start}
 import org.opencypher.spark.impl.{CAPSGraph, CAPSRecords}
-import org.opencypher.spark.impl.physical.operators.{Cache, CartesianProduct, Scan, Start}
 import org.opencypher.spark.test.CAPSTestSuite
 import org.opencypher.spark.test.fixture.GraphCreationFixture
 


### PR DESCRIPTION
This PR replaces some of the "graph specific" operators (e.g. `ExpandSource` and `ExpandInto`) as we;; as "special" operators (e.g. value join) and replaces them with pure relational operations (i.e. `Join` and `Selection/Filter`). This reduces complexity of the physical operators and requires less implementation effort for alternative relational backends. It also brings us closer to a pure relational output in `okapi-relational`. 

An example physical plan now looks like that:
```
|-SelectFields(List(nodes :: INTEGER), RecordHeader with 1 slots)
· |-Aggregate(Set((nodes :: INTEGER,count(b :: :B NODE @ tmp#15))), Set(), RecordHeader with 1 slots)
· · |-Join(List((target(  UNNAMED10 :: RELATIONSHIP @ tmp#15),b :: NODE @ tmp#15)), RecordHeader with 9 slots)
· · · |-Join(List((n :: NODE @ tmp#15,source(  UNNAMED10 :: RELATIONSHIP @ tmp#15))), RecordHeader with 7 slots)
· · · · |-NodeScan(n :: NODE, RecordHeader with 3 slots)
· · · · · |-Start(CAPSRecords.unit, org.opencypher.spark.impl.CAPSPatternGraph@388db4a6)
· · · · |-RelationshipScan(  UNNAMED10 :: RELATIONSHIP @ tmp#15, RecordHeader with 4 slots)
· · · · · |-Start(org.opencypher.spark.impl.CAPSPatternGraph@388db4a6)
· · · |-NodeScan(b :: :B NODE, RecordHeader with 2 slots)
· · · · |-Start(CAPSRecords.unit, org.opencypher.spark.impl.CAPSPatternGraph@388db4a6)
```