### PR TITLE
Compute join fields on slot contents in OPTIONAL MATCH

### DIFF
--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalPlanner.scala
@@ -229,22 +229,20 @@ class PhysicalPlanner[P <: PhysicalOperator[R, G, C], R <: CypherRecords, G <: P
     val lhsHeader = lhs.header
     val rhsHeader = rhs.header
 
-
     // 1. Compute fields between left and right side
-    val commonFields = lhsHeader.slots.intersect(rhsHeader.slots)
+    val commonFields = lhsHeader.slots.map(_.content).intersect(rhsHeader.slots.map(_.content))
 
     val (joinSlots, otherCommonSlots) = commonFields.partition {
-      case RecordSlot(_, _: OpaqueField) => true
-      case RecordSlot(_, _) => false
+      case _: OpaqueField => true
+      case _ => false
     }
 
     val joinFields = joinSlots
-      .map(_.content)
       .collect { case OpaqueField(v) => v }
       .distinct
 
     val otherCommonFields = otherCommonSlots
-      .map(_.content.key)
+      .map(_.key)
 
     // 2. Remove siblings of the join fields and other common fields
     val fieldsToRemove = joinFields

--- a/spark-cypher-tck/src/test/resources/scenario_blacklist
+++ b/spark-cypher-tck/src/test/resources/scenario_blacklist
@@ -275,7 +275,6 @@ Feature "OrderByAcceptance": Scenario "ORDER BY with a negative LIMIT should fai
 Feature "OptionalMatchAcceptance": Scenario "Returning label predicate on null node"
 Feature "OptionalMatchAcceptance": Scenario "WITH after OPTIONAL MATCH"
 Feature "OptionalMatchAcceptance": Scenario "Named paths in optional matches"
-Feature "OptionalMatchAcceptance": Scenario "OPTIONAL MATCH and bound nodes"
 Feature "OptionalMatchAcceptance": Scenario "Named paths inside optional matches with node predicates"
 Feature "OptionalMatchAcceptance": Scenario "Variable length optional relationships"
 Feature "OptionalMatchAcceptance": Scenario "Variable length optional relationships with length predicates"


### PR DESCRIPTION
The previous code failed when record slots had different indices.