### PR TITLE
 Rework license listing and profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - PROFILE=test
     - PROFILE=check
 
+install: true
+
 script:
   - if [ "$PROFILE" = "test" ]; then mvn clean test; fi
   - if [ "$PROFILE" = "check" ]; then mvn clean compile -Dcluster; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ env:
 install: echo "skip preparatory install"
 
 script:
-  - if [ "$PROFILE" = "test" ]; then mvn clean test; fi
-  - if [ "$PROFILE" = "check" ]; then mvn clean install -Dcluster -DskipTests; fi
+  - if [ "$PROFILE" = "test" ]; then mvn -q clean test; fi
+  - if [ "$PROFILE" = "check" ]; then mvn -q clean install -Dcluster -DskipTests; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ scala:
 
 env:
   matrix:
-    - PROFILE=standalone
+    - COMMAND=compile -Dcluster
+    - COMMAND=test
 
-script: "mvn clean install -P ${PROFILE}"
+script: "mvn clean ${COMMAND}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ scala:
 
 env:
   matrix:
-    - COMMAND=compile -Dcluster
-    - COMMAND=test
+    - PROFILE=test
+    - PROFILE=check
 
-script: "mvn clean ${COMMAND}"
+script:
+  - if [ "$PROFILE" = "test" ]; then mvn clean test; fi
+  - if [ "$PROFILE" = "check" ]; then mvn clean compile -Dcluster; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - PROFILE=test
     - PROFILE=check
 
-install: true
+install: echo "skip preparatory install"
 
 script:
   - if [ "$PROFILE" = "test" ]; then mvn clean test; fi
-  - if [ "$PROFILE" = "check" ]; then mvn clean compile -Dcluster; fi
+  - if [ "$PROFILE" = "check" ]; then mvn clean install -Dcluster -DskipTests; fi

--- a/licensecheck-config/README.adoc
+++ b/licensecheck-config/README.adoc
@@ -9,6 +9,8 @@ Most open source licenses are allowed, https://www.apache.org/licenses/GPL-compa
 Apache Spark does bundle a number of GPL-licensed modules; most are dual-licensed with CDDL.
 We accept these as they are distributed to us through Spark.
 
+The license listing is only activated in the `cluster` Maven profile.
+
 == Usage
 
 When a dependency is added or removed, the license listings need to be updated.
@@ -16,11 +18,12 @@ The check is done via Maven, tied to the `compile` phase*.
 To make the tool generate new listings instead of comparing to the checked-in lists, add the `-Doverwrite` parameter:
 
 ```
-mvn compile -Doverwrite
+mvn install -Dcluster -Doverwrite -DskipTests
 ```
 
 *This is necessary because the configuration module must be compiled for an updated configuration to be available (if a new liked license is added).
 It would otherwise have been sufficient with `validate` phase.
+Unfortunately, due to the Maven profiles (we think?) we have to execute `install` for it to pick up inter-modular dependencies (api on trees, f.e.).
 
 == Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,20 +39,6 @@
     </developer>
   </developers>
 
-  <modules>
-    <module>licensecheck-config</module>
-    <module>okapi-api</module>
-    <module>okapi-ir</module>
-    <module>okapi-logical</module>
-    <module>okapi-relational</module>
-    <module>okapi-tck</module>
-    <module>okapi-trees</module>
-    <module>okapi-testing</module>
-    <module>spark-cypher</module>
-    <module>spark-cypher-examples</module>
-    <module>spark-cypher-tck</module>
-  </modules>
-
   <properties>
     <!-- Encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -380,6 +366,9 @@
         <file>
           <exists>src/main/scala</exists>
         </file>
+        <property>
+          <name>cluster</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -395,12 +384,24 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <id>standalone</id>
+      <id>testing</id>
       <properties>
-        <project.artifact.classifier>standalone</project.artifact.classifier>
         <dep.spark.scope>compile</dep.spark.scope>
-        <buildShade>true</buildShade>
       </properties>
+
+      <!-- No license listing for this profile -->
+      <modules>
+        <module>okapi-api</module>
+        <module>okapi-ir</module>
+        <module>okapi-logical</module>
+        <module>okapi-relational</module>
+        <module>okapi-tck</module>
+        <module>okapi-trees</module>
+        <module>okapi-testing</module>
+        <module>spark-cypher</module>
+        <module>spark-cypher-examples</module>
+        <module>spark-cypher-tck</module>
+      </modules>
     </profile>
 
     <profile>
@@ -409,6 +410,23 @@
         <project.artifact.classifier>cluster</project.artifact.classifier>
         <dep.spark.scope>provided</dep.spark.scope>
       </properties>
+      <activation>
+        <property>
+          <name>cluster</name>
+        </property>
+      </activation>
+
+      <!-- We're skipping TCK and examples -->
+      <modules>
+        <module>licensecheck-config</module>
+        <module>okapi-api</module>
+        <module>okapi-ir</module>
+        <module>okapi-logical</module>
+        <module>okapi-relational</module>
+        <module>okapi-trees</module>
+        <module>spark-cypher</module>
+      </modules>
+
       <build>
         <plugins>
           <!-- shade plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,8 @@
         <module>okapi-ir</module>
         <module>okapi-logical</module>
         <module>okapi-relational</module>
+        <module>okapi-tck</module>
+        <module>okapi-testing</module>
         <module>okapi-trees</module>
         <module>spark-cypher</module>
       </modules>

--- a/scripts/release/src/main/scala/org/opencypher/github/release/CreateGitHubRelease.scala
+++ b/scripts/release/src/main/scala/org/opencypher/github/release/CreateGitHubRelease.scala
@@ -70,10 +70,8 @@ case class GithubRelease(config: Config) {
 
   def uploadJars(releaseId: String): Unit = {
     val clusterJarAsset = s"spark-cypher-${config.releaseVersion}-cluster.jar"
-    val standaloneJarAsset = s"spark-cypher-${config.releaseVersion}.jar"
 
     val clusterJarPath = Paths.get(config.assetFolder, clusterJarAsset)
-    val standaloneJarPath = Paths.get(config.assetFolder, standaloneJarAsset)
 
     def uploadAsset(releaseId: String, assetName: String, file: File) = {
       val requestUri = buildRequestUri(GH_UPLOAD_URL, s"/releases/$releaseId/assets", "name" -> assetName)
@@ -90,7 +88,6 @@ case class GithubRelease(config: Config) {
     }
 
     uploadAsset(releaseId, clusterJarAsset, clusterJarPath.toFile)
-    uploadAsset(releaseId, standaloneJarAsset, standaloneJarPath.toFile)
   }
 
   private def buildRequestUri(base: String, path: String, parameters: (String, String)*): Uri = {
@@ -117,7 +114,8 @@ case class Config(
     s"""
        |### `spark-cypher-$releaseVersion`
        |
-       |This is the artifact deployed to [Maven Central](https://search.maven.org/#artifactdetails%7Corg.opencypher%7Cspark-cypher%7C$releaseVersion%7Cjar). To use this release in a Maven project, add the following dependency to your pom:
+       |The artifact is released to [Maven Central](https://search.maven.org/#artifactdetails%7Corg.opencypher%7Cspark-cypher%7C$releaseVersion%7Cjar).
+       |To use it in a Maven project, add the following dependency to your pom:
        |```
        |<dependency>
        |  <groupId>org.opencypher</groupId>

--- a/spark-cypher-examples/pom.xml
+++ b/spark-cypher-examples/pom.xml
@@ -18,22 +18,6 @@
     <project.rootdir>${project.parent.basedir}</project.rootdir>
   </properties>
 
-  <build>
-    <plugins>
-      <!-- Disable license listing plugin -->
-      <plugin>
-        <groupId>org.neo4j.build.plugins</groupId>
-        <artifactId>licensing-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>list-all-licenses</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>org.opencypher</groupId>

--- a/spark-cypher/LICENSES.txt
+++ b/spark-cypher/LICENSES.txt
@@ -4,149 +4,25 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  aopalliance version 1.0 repackaged as a module
-  Apache Avro
-  Apache Avro IPC
-  Apache Avro Mapred API
-  Apache Commons Codec
-  Apache Commons Configuration
-  Apache Commons Crypto
   Apache Commons Lang
-  Apache Commons Logging
-  Apache Commons Math
-  Apache Directory API ASN.1 API
-  Apache Directory LDAP API Utilities
-  Apache Hadoop Annotations
-  Apache Hadoop Auth
-  Apache Hadoop Client
-  Apache Hadoop Common
-  Apache Hadoop HDFS
-  Apache HttpClient
-  Apache HttpCore
-  Apache Ivy
-  Apache Log4j
-  Apache Parquet Column
-  Apache Parquet Common
-  Apache Parquet Encodings
-  Apache Parquet Format
-  Apache Parquet Hadoop
-  Apache Parquet Jackson
-  ApacheDS I18n
-  ApacheDS Protocol Kerberos Codec
-  Bean Validation API
-  chill
-  chill-java
   Circe core
   Circe generic
   Circe jawn
   Circe numbers
   Circe parser
-  Commons CLI
-  Commons Collections
-  Commons Compress
-  Commons Daemon
-  Commons IO
-  Commons Lang
-  Commons Net
-  Compress-LZF
   core
   coreJVM
-  Curator Client
-  Curator Framework
-  Curator Recipes
-  Data Mapper for Jackson
-  empty
-  FindBugs-jsr305
-  Google Guice - Core Library
-  Google Guice - Extensions - Servlet
-  Graphite Integration for Metrics
-  Gson
-  Guava: Google Core Libraries for Java
-  hadoop-mapreduce-client-app
-  hadoop-mapreduce-client-common
-  hadoop-mapreduce-client-core
-  hadoop-mapreduce-client-jobclient
-  hadoop-mapreduce-client-shuffle
-  hadoop-yarn-api
-  hadoop-yarn-client
-  hadoop-yarn-common
-  hadoop-yarn-server-common
-  hadoop-yarn-server-nodemanager
-  hadoop-yarn-server-web-proxy
-  HK2 API module
-  HK2 Implementation Utilities
-  htrace-core
-  HttpClient
-  Jackson
-  Jackson Integration for Metrics
-  Jackson-annotations
-  Jackson-core
-  jackson-databind
-  Jackson-module-paranamer
-  jackson-module-scala
-  Java Servlet API
-  java-xmlbuilder
-  JavaBeans(TM) Activation Framework
-  JavaMail API (compat)
-  Javassist
-  javax.annotation API
-  javax.inject
-  javax.inject:1 as OSGi bundle
-  javax.ws.rs-api
-  JAX-RS provider for JSON content type
-  jersey-container-servlet
-  jersey-container-servlet-core
-  jersey-core-client
-  jersey-core-common
-  jersey-core-server
-  jersey-media-jaxb
-  jersey-repackaged-guava
-  JetS3t
-  Jettison
-  Jetty Server
-  Jetty Utilities
-  json4s-ast
-  json4s-core
-  json4s-jackson
-  JVM Integration for Metrics
-  LZ4 and xxHash
-  Metrics Core
-  MX4J
   Neo4j - Cypher Expressions 3.4
   Neo4j - Cypher Util 3.4
   Neo4j Java Driver
-  Netty
-  Netty/All-in-One
-  Objenesis
   Okapi - openCypher API
   Okapi IR - Declarative representation of Cypher queries
   Okapi Logical - Logical representation of Cypher queries
   Okapi Relational - Relational Algebra for Cypher
   Okapi Trees - Tree rewriting framework for Okapi
   openCypher Frontend
-  oro
-  OSGi resource locator bundle - used by various API providers that rely on META-INF/services mechanism to locate providers.
   parboiled-core
   parboiled-scala
-  RoaringBitmap
-  ServiceLocator Default Implementation
-  servlet-api
-  snappy-java
-  Spark Project Catalyst
-  Spark Project Core
-  Spark Project Launcher
-  Spark Project Networking
-  Spark Project Shuffle Streaming Service
-  Spark Project Sketch
-  Spark Project SQL
-  Spark Project Tags
-  Spark Project Unsafe
-  stream-lib
-  univocity-parsers
-  Xerces2 Java Parser
-  XML Commons External Components XML APIs
-  Xml Compatibility extensions for Jackson
-  zookeeper
 ------------------------------------------------------------------------------
 
                                  Apache License
@@ -355,22 +231,10 @@ Apache Software License, Version 2.0
 
 ------------------------------------------------------------------------------
 BSD License
-  ANTLR 4 Runtime
-  Commons Compiler
-  Janino
-  JSch
-  Kryo Shaded
-  leveldbjni-all
-  MinLog
-  ParaNamer Core
-  Protocol Buffer Java API
-  Py4J
   Scala Compiler
   Scala Library
   scala-parser-combinators
   scala-xml
-  Scalap
-  xmlenc Library
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>
@@ -401,50 +265,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ------------------------------------------------------------------------------
-Bouncy Castle License
-  Bouncy Castle Provider
-------------------------------------------------------------------------------
-
-Please note: our license is an adaptation of the MIT X11 License and should be
-read as such.
-
-LICENSE
-
-Copyright (c) 2000 - 2011 The Legion Of The Bouncy Castle
-(http://www.bouncycastle.org)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-
-------------------------------------------------------------------------------
 MIT-license
   Cats core
   Cats kernel
   Cats macros
   core
-  JCL 1.1.1 implemented over SLF4J
-  JUL to SLF4J bridge
   machinist
   parser
-  pyrolite
-  SLF4J API Module
-  SLF4J LOG4J-12 Binding
 ------------------------------------------------------------------------------
 
 The MIT License
@@ -468,16 +295,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-
-
-------------------------------------------------------------------------------
-Public-domain
-  AOP alliance
-  base64
-  XZ for Java
-------------------------------------------------------------------------------
-
 
 
 

--- a/spark-cypher/NOTICE.txt
+++ b/spark-cypher/NOTICE.txt
@@ -28,186 +28,37 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  aopalliance version 1.0 repackaged as a module
-  Apache Avro
-  Apache Avro IPC
-  Apache Avro Mapred API
-  Apache Commons Codec
-  Apache Commons Configuration
-  Apache Commons Crypto
   Apache Commons Lang
-  Apache Commons Logging
-  Apache Commons Math
-  Apache Directory API ASN.1 API
-  Apache Directory LDAP API Utilities
-  Apache Hadoop Annotations
-  Apache Hadoop Auth
-  Apache Hadoop Client
-  Apache Hadoop Common
-  Apache Hadoop HDFS
-  Apache HttpClient
-  Apache HttpCore
-  Apache Ivy
-  Apache Log4j
-  Apache Parquet Column
-  Apache Parquet Common
-  Apache Parquet Encodings
-  Apache Parquet Format
-  Apache Parquet Hadoop
-  Apache Parquet Jackson
-  ApacheDS I18n
-  ApacheDS Protocol Kerberos Codec
-  Bean Validation API
-  chill
-  chill-java
   Circe core
   Circe generic
   Circe jawn
   Circe numbers
   Circe parser
-  Commons CLI
-  Commons Collections
-  Commons Compress
-  Commons Daemon
-  Commons IO
-  Commons Lang
-  Commons Net
-  Compress-LZF
   core
   coreJVM
-  Curator Client
-  Curator Framework
-  Curator Recipes
-  Data Mapper for Jackson
-  empty
-  FindBugs-jsr305
-  Google Guice - Core Library
-  Google Guice - Extensions - Servlet
-  Graphite Integration for Metrics
-  Gson
-  Guava: Google Core Libraries for Java
-  hadoop-mapreduce-client-app
-  hadoop-mapreduce-client-common
-  hadoop-mapreduce-client-core
-  hadoop-mapreduce-client-jobclient
-  hadoop-mapreduce-client-shuffle
-  hadoop-yarn-api
-  hadoop-yarn-client
-  hadoop-yarn-common
-  hadoop-yarn-server-common
-  hadoop-yarn-server-nodemanager
-  hadoop-yarn-server-web-proxy
-  HK2 API module
-  HK2 Implementation Utilities
-  htrace-core
-  HttpClient
-  Jackson
-  Jackson Integration for Metrics
-  Jackson-annotations
-  Jackson-core
-  jackson-databind
-  Jackson-module-paranamer
-  jackson-module-scala
-  Java Servlet API
-  java-xmlbuilder
-  JavaBeans(TM) Activation Framework
-  JavaMail API (compat)
-  Javassist
-  javax.annotation API
-  javax.inject
-  javax.inject:1 as OSGi bundle
-  javax.ws.rs-api
-  JAX-RS provider for JSON content type
-  jersey-container-servlet
-  jersey-container-servlet-core
-  jersey-core-client
-  jersey-core-common
-  jersey-core-server
-  jersey-media-jaxb
-  jersey-repackaged-guava
-  JetS3t
-  Jettison
-  Jetty Server
-  Jetty Utilities
-  json4s-ast
-  json4s-core
-  json4s-jackson
-  JVM Integration for Metrics
-  LZ4 and xxHash
-  Metrics Core
-  MX4J
   Neo4j - Cypher Expressions 3.4
   Neo4j - Cypher Util 3.4
   Neo4j Java Driver
-  Netty
-  Netty/All-in-One
-  Objenesis
   Okapi - openCypher API
   Okapi IR - Declarative representation of Cypher queries
   Okapi Logical - Logical representation of Cypher queries
   Okapi Relational - Relational Algebra for Cypher
   Okapi Trees - Tree rewriting framework for Okapi
   openCypher Frontend
-  oro
-  OSGi resource locator bundle - used by various API providers that rely on META-INF/services mechanism to locate providers.
   parboiled-core
   parboiled-scala
-  RoaringBitmap
-  ServiceLocator Default Implementation
-  servlet-api
-  snappy-java
-  Spark Project Catalyst
-  Spark Project Core
-  Spark Project Launcher
-  Spark Project Networking
-  Spark Project Shuffle Streaming Service
-  Spark Project Sketch
-  Spark Project SQL
-  Spark Project Tags
-  Spark Project Unsafe
-  stream-lib
-  univocity-parsers
-  Xerces2 Java Parser
-  XML Commons External Components XML APIs
-  Xml Compatibility extensions for Jackson
-  zookeeper
 
 BSD License
-  ANTLR 4 Runtime
-  Commons Compiler
-  Janino
-  JSch
-  Kryo Shaded
-  leveldbjni-all
-  MinLog
-  ParaNamer Core
-  Protocol Buffer Java API
-  Py4J
   Scala Compiler
   Scala Library
   scala-parser-combinators
   scala-xml
-  Scalap
-  xmlenc Library
-
-Bouncy Castle License
-  Bouncy Castle Provider
 
 MIT-license
   Cats core
   Cats kernel
   Cats macros
   core
-  JCL 1.1.1 implemented over SLF4J
-  JUL to SLF4J bridge
   machinist
   parser
-  pyrolite
-  SLF4J API Module
-  SLF4J LOG4J-12 Binding
-
-Public-domain
-  AOP alliance
-  base64
-  XZ for Java
 


### PR DESCRIPTION
- The testing profile doesn't do license listing and checking
- The cluster profile includes license listing, but only production modules

The testing profile is active by default, the cluster profile is
activated by supplying `-Dcluster` to the Maven command

- New license listings where Spark is not included for spark-cypher