### PR TITLE
Simplify entity table construction from DataFrames

### DIFF
--- a/spark-cypher-examples/README.md
+++ b/spark-cypher-examples/README.md
@@ -12,6 +12,7 @@ These examples are currently present:
 * [`CaseClassExample`](src/main/scala/org/opencypher/spark/examples/CaseClassExample.scala)
 * [`CypherSQLRoundtripExample`](src/main/scala/org/opencypher/spark/examples/CypherSQLRoundtripExample.scala)
 * [`DataFrameInputExample`](src/main/scala/org/opencypher/spark/examples/DataFrameInputExample.scala)
+* [`CustomDataFrameInputExample`](src/main/scala/org/opencypher/spark/examples/CustomDataFrameInputExample.scala)
 * [`DataFrameOutputExample`](src/main/scala/org/opencypher/spark/examples/DataFrameOutputExample.scala)
 * [`DataSourceExample`](src/main/scala/org/opencypher/spark/examples/DataSourceExample.scala)
 * [`GraphXPageRankExample`](src/main/scala/org/opencypher/spark/examples/GraphXPageRankExample.scala)

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CustomDataFrameInputExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CustomDataFrameInputExample.scala
@@ -35,22 +35,62 @@ import org.opencypher.spark.api.io.{CAPSNodeTable, CAPSRelationshipTable}
 import scala.collection.JavaConverters._
 
 /**
-  * Demonstrates basic usage of the CAPS API by loading an example network from existing [[DataFrame]]s and
-  * running a Cypher query on it.
+  * Demonstrates basic usage of the CAPS API by loading an example network from existing [[DataFrame]]s including
+  * custom entity mappings and running a Cypher query on it.
   */
-object DataFrameInputExample extends App {
+object CustomDataFrameInputExample extends App {
   // 1) Create CAPS session and retrieve Spark session
   implicit val session: CAPSSession = CAPSSession.local()
   val spark = session.sparkSession
 
   // 2) Generate some DataFrames that we'd like to interpret as a property graph.
-  val nodesDF = SocialNetworkDataFrames.nodes(spark)
-  val relsDF = SocialNetworkDataFrames.rels(spark)
+  val nodesDF: DataFrame = {
+    val nodes = List(
+      Row(0L, "Alice", 42L),
+      Row(1L, "Bob", 23L),
+      Row(2L, "Eve", 84L)
+    ).asJava
+    val nodeSchema = StructType(List(
+      StructField("NODE_ID", LongType, false),
+      StructField("FIRST_NAME", StringType, false),
+      StructField("AGE", LongType, false))
+    )
+    spark.createDataFrame(nodes, nodeSchema)
+  }
 
-  // 3) Generate node- and relationship tables that wrap the DataFrames. The mapping between graph entities and columns
-  //    is derived using naming conventions for identifier columns.
-  val personTable = CAPSNodeTable(Set("Person"), nodesDF)
-  val friendsTable = CAPSRelationshipTable("KNOWS", relsDF)
+  val relsDF: DataFrame = {
+    val rels = List(
+      Row(0L, 0L, 1L, "23/01/1987"),
+      Row(1L, 1L, 2L, "12/12/2009")
+    ).asJava
+    val relSchema = StructType(List(
+      StructField("REL_ID", LongType, false),
+      StructField("SOURCE_ID", LongType, false),
+      StructField("TARGET_ID", LongType, false),
+      StructField("CONNECTED_SINCE", StringType, false))
+    )
+    spark.createDataFrame(rels, relSchema)
+  }
+
+  // 3) Generate node- and relationship tables that wrap the DataFrames and describe their contained data.
+  //    Node and relationship mappings are used to explicitly define which DataFrame column stores which specific entity
+  //    component (identifiers, properties, optional labels, relationship types).
+
+  val personNodeMapping = NodeMapping
+    .withSourceIdKey("NODE_ID")
+    .withImpliedLabel("Person")
+    .withPropertyKey(propertyKey = "name", sourcePropertyKey = "FIRST_NAME")
+    .withPropertyKey(propertyKey = "age", sourcePropertyKey = "AGE")
+
+  val friendOfMapping = RelationshipMapping
+    .withSourceIdKey("REL_ID")
+    .withSourceStartNodeKey("SOURCE_ID")
+    .withSourceEndNodeKey("TARGET_ID")
+    .withRelType("FRIEND_OF")
+    .withPropertyKey("since", "CONNECTED_SINCE")
+
+  val personTable = CAPSNodeTable(personNodeMapping, nodesDF)
+  val friendsTable = CAPSRelationshipTable(friendOfMapping, relsDF)
 
   // 4) Create property graph from graph scans
   val graph = session.readFrom(personTable, friendsTable)
@@ -66,34 +106,32 @@ object DataFrameInputExample extends App {
   val unsafeNames: Set[String] = result.getRecords.collect.map(_ ("n.name").cast[String]).toSet
 
   println(safeNames)
-}
 
-object SocialNetworkDataFrames {
-  def nodes(session: SparkSession): DataFrame = {
+  def nodes: DataFrame = {
     val nodes = List(
       Row(0L, "Alice", 42L),
       Row(1L, "Bob", 23L),
       Row(2L, "Eve", 84L)
     ).asJava
     val nodeSchema = StructType(List(
-      StructField("id", LongType, false),
-      StructField("name", StringType, false),
-      StructField("age", LongType, false))
+      StructField("NODE_ID", LongType, false),
+      StructField("FIRST_NAME", StringType, false),
+      StructField("AGE", LongType, false))
     )
-    session.createDataFrame(nodes, nodeSchema)
+    spark.createDataFrame(nodes, nodeSchema)
   }
 
-  def rels(session: SparkSession): DataFrame = {
+  def rels: DataFrame = {
     val rels = List(
       Row(0L, 0L, 1L, "23/01/1987"),
       Row(1L, 1L, 2L, "12/12/2009")
     ).asJava
     val relSchema = StructType(List(
-      StructField("id", LongType, false),
-      StructField("source", LongType, false),
-      StructField("target", LongType, false),
-      StructField("since", StringType, false))
+      StructField("REL_ID", LongType, false),
+      StructField("SOURCE_ID", LongType, false),
+      StructField("TARGET_ID", LongType, false),
+      StructField("CONNECTED_SINCE", StringType, false))
     )
-    session.createDataFrame(rels, relSchema)
+    spark.createDataFrame(rels, relSchema)
   }
 }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/EntityTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/EntityTable.scala
@@ -117,11 +117,11 @@ object CAPSNodeTable {
     * columns, the column name is used as property key.
     *
     * @param impliedLabels implied node labels
-    * @param table         Spark table
+    * @param nodeDF        node data
     * @return a node table with inferred node mapping
     */
-  def apply(impliedLabels: Set[String], table: SparkTable): CAPSNodeTable =
-    CAPSNodeTable(impliedLabels, Map.empty, table)
+  def apply(impliedLabels: Set[String], nodeDF: DataFrame): CAPSNodeTable =
+    CAPSNodeTable(impliedLabels, Map.empty, nodeDF)
 
   /**
     * Creates a node table from the given [[DataFrame]]. By convention, there needs to be one column storing node
@@ -131,11 +131,10 @@ object CAPSNodeTable {
     *
     * @param impliedLabels  implied node labels
     * @param optionalLabels mapping from optional labels to column names
-    * @param table          Spark table
+    * @param nodeDF         node data
     * @return a node table with inferred node mapping
     */
-  def apply(impliedLabels: Set[String], optionalLabels: Map[String, String], table: SparkTable): CAPSNodeTable = {
-    val nodeDF = table.df
+  def apply(impliedLabels: Set[String], optionalLabels: Map[String, String], nodeDF: DataFrame): CAPSNodeTable = {
     val nodeProperties = (properties(nodeDF.columns) -- optionalLabels.values).map(col => col -> col).toMap
     val nodeMapping = NodeMapping(GraphEntity.sourceIdKey, impliedLabels, optionalLabels, nodeProperties)
     CAPSNodeTable(nodeMapping, nodeDF)
@@ -172,11 +171,10 @@ object CAPSRelationshipTable {
     * column name is used as property key.
     *
     * @param relationshipType relationship type
-    * @param table            Spark table
+    * @param relationshipDF   relationship data
     * @return a relationship table with inferred relationship mapping
     */
-  def apply(relationshipType: String, table: SparkTable): CAPSRelationshipTable = {
-    val relationshipDF = table.df
+  def apply(relationshipType: String, relationshipDF: DataFrame): CAPSRelationshipTable = {
     val relationshipProperties = properties(relationshipDF.columns)
 
     val relationshipMapping = RelationshipMapping.create(GraphEntity.sourceIdKey,

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/table/EntityTableTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/table/EntityTableTest.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.DecimalType
 import org.opencypher.okapi.api.io.conversion.{NodeMapping, RelationshipMapping}
 import org.opencypher.okapi.api.schema.Schema
-import org.opencypher.okapi.api.types.{CTFloat, CTInteger, CTString}
+import org.opencypher.okapi.api.types.{CTBoolean, CTFloat, CTInteger, CTString}
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
 import org.opencypher.spark.api.io._
@@ -158,5 +158,31 @@ class EntityTableTest extends CAPSTestSuite {
       val nodeMapping = NodeMapping.on("ID").withOptionalLabel("A" -> "IS_A").withPropertyKey("PROP")
       CAPSNodeTable(nodeMapping, df)
     }
+  }
+
+  it("should infer the correct node mapping") {
+    val df = session.createDataFrame(Seq((1, "Alice", 1984, true, 13.37)))
+      .toDF("id", "name", "birthYear", "isGood", "luckyNumber")
+
+    val nodeTable = CAPSNodeTable(Set("Person"), df)
+
+    nodeTable.schema should equal(Schema.empty
+      .withNodePropertyKeys("Person")(
+        "name" -> CTString.nullable,
+        "birthYear" -> CTInteger,
+        "isGood" -> CTBoolean,
+        "luckyNumber" -> CTFloat)
+      .asCaps)
+  }
+
+  it("should infer the correct node mapping including optional labels") {
+    val df = session.createDataFrame(Seq((1, "Alice", true))).toDF("id", "name", "IS_SWEDE")
+
+    val nodeTable = CAPSNodeTable(Set("Person"), Map("Swede" -> "IS_SWEDE"), df)
+
+    nodeTable.schema should equal(Schema.empty
+      .withNodePropertyKeys("Person", "Swede")("name" -> CTString.nullable)
+      .withNodePropertyKeys("Person")("name" -> CTString.nullable)
+      .asCaps)
   }
 }

--- a/spark-cypher/src/test/scala/org/opencypher/spark/impl/table/EntityTableTest.scala
+++ b/spark-cypher/src/test/scala/org/opencypher/spark/impl/table/EntityTableTest.scala
@@ -160,7 +160,7 @@ class EntityTableTest extends CAPSTestSuite {
     }
   }
 
-  it("should infer the correct node mapping") {
+  test("NodeTable should infer the correct node mapping") {
     val df = session.createDataFrame(Seq((1, "Alice", 1984, true, 13.37)))
       .toDF("id", "name", "birthYear", "isGood", "luckyNumber")
 
@@ -175,7 +175,7 @@ class EntityTableTest extends CAPSTestSuite {
       .asCaps)
   }
 
-  it("should infer the correct node mapping including optional labels") {
+  test("NodeTable should infer the correct node mapping including optional labels") {
     val df = session.createDataFrame(Seq((1, "Alice", true))).toDF("id", "name", "IS_SWEDE")
 
     val nodeTable = CAPSNodeTable(Set("Person"), Map("Swede" -> "IS_SWEDE"), df)
@@ -183,6 +183,21 @@ class EntityTableTest extends CAPSTestSuite {
     nodeTable.schema should equal(Schema.empty
       .withNodePropertyKeys("Person", "Swede")("name" -> CTString.nullable)
       .withNodePropertyKeys("Person")("name" -> CTString.nullable)
+      .asCaps)
+  }
+
+  test("RelationshipTable should infer the correct relationship mapping") {
+    val df = session.createDataFrame(Seq((1, 1, 1, "Alice", 1984, true, 13.37)))
+      .toDF("id", "source", "target", "name", "birthYear", "isGood", "luckyNumber")
+
+    val relationshipTable = CAPSRelationshipTable("KNOWS", df)
+
+    relationshipTable.schema should equal(Schema.empty
+        .withRelationshipPropertyKeys("KNOWS")(
+        "name" -> CTString.nullable,
+        "birthYear" -> CTInteger,
+        "isGood" -> CTBoolean,
+        "luckyNumber" -> CTFloat)
       .asCaps)
   }
 }


### PR DESCRIPTION
Introduces automatic construction of entity mappings by exploiting naming conventions on DataFrame columns. 

Fixes #359