### PR TITLE
More error output to pinpoint the cause of our spurious TravisCI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ env:
 install: echo "skip preparatory install"
 
 script:
-  - if [ "$PROFILE" = "test" ]; then mvn -q clean test; fi
-  - if [ "$PROFILE" = "check" ]; then mvn -q clean install -Dcluster -DskipTests; fi
+  - if [ "$PROFILE" = "test" ]; then mvn -e -q clean test; fi
+  - if [ "$PROFILE" = "check" ]; then mvn -e -q clean install -Dcluster -DskipTests; fi


### PR DESCRIPTION
Example: Current master build is spuriously failing, same with this PR: https://github.com/opencypher/cypher-for-apache-spark/pull/416