### PR TITLE
Improve tree pretty printing

### DIFF
--- a/okapi-trees/src/main/scala/org/opencypher/okapi/trees/TreeNode.scala
+++ b/okapi-trees/src/main/scala/org/opencypher/okapi/trees/TreeNode.scala
@@ -26,6 +26,7 @@
  */
 package org.opencypher.okapi.trees
 
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
 
@@ -126,19 +127,35 @@ abstract class TreeNode[T <: TreeNode[T]: ClassTag] extends Product with Travers
   }
 
   /**
-    * Prints the tree node and its children recursively in a tree-style layout.
+    * Returns a string-tree representation of the node.
     *
-    * @param depth indentation depth used by the recursive call
-    * @return tree-style representation of that node and all (grand-)children
+    * @return tree-style representation of that node and all children
     */
-  def pretty(implicit depth: Int = 0): String = {
+  def pretty: String = {
+    val lines = new ArrayBuffer[String]
 
-    def prefix(depth: Int): String = ("· " * depth) + "|-"
-
-    val childrenString = children.foldLeft(new StringBuilder()) {
-      case (agg, s) => agg.append(s.pretty(depth + 1))
+    def recTreeToString(toPrint: List[T], prefix: String): Unit = {
+      toPrint match {
+        case Nil =>
+        case last :: Nil =>
+          lines += s"$prefix╙──${last.toString}"
+          recTreeToString(last.children.toList, s"$prefix    ")
+        case next :: siblings =>
+          lines += s"$prefix╟──${next.toString}"
+          recTreeToString(next.children.toList, s"$prefix║   ")
+          recTreeToString(siblings, prefix)
+      }
     }
-    s"${prefix(depth)}$self\n$childrenString"
+
+    recTreeToString(List(this), "")
+    lines.mkString("\n")
+  }
+
+  /**
+    * Prints a tree representation of the node.
+    */
+  def show(): Unit = {
+    println(pretty)
   }
 
   /**

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSSessionImpl.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSSessionImpl.scala
@@ -190,7 +190,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession)
     logStageProgress("Done!")
     if (PrintLogicalPlan.isSet) {
       println("Optimized logical plan:")
-      println(optimizedLogicalPlan.pretty())
+      optimizedLogicalPlan.show()
     }
     optimizedLogicalPlan
   }
@@ -207,7 +207,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession)
     logStageProgress("Done!")
     if (PrintFlatPlan.isSet) {
       println("Flat plan:")
-      println(flatPlan.pretty())
+      flatPlan.show()
     }
 
     logStageProgress("Physical planning ... ", newLine = false)
@@ -216,7 +216,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession)
     logStageProgress("Done!")
     if (PrintPhysicalPlan.isSet) {
       println("Physical plan:")
-      println(physicalPlan.pretty())
+      physicalPlan.show()
     }
 
 
@@ -225,7 +225,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession)
     logStageProgress("Done!")
     if (PrintOptimizedPhysicalPlan.isSet) {
       println("Optimized physical plan:")
-      println(optimizedPhysicalPlan.pretty())
+      optimizedPhysicalPlan.show()
     }
 
     val graphAt = (qgn: QualifiedGraphName) => Some(catalog.graph(qgn).asCaps)


### PR DESCRIPTION
`Add(Add(Add(Number(4), Number(3)), Add(Number(4), Number(3))), Add(Add(Number(4), Number(3)), Add(Number(4), Number(3)))).show`

Before:
```
|-Add
· |-Add
· · |-Add
· · · |-Number(4)
· · · |-Number(3)
· · |-Add
· · · |-Number(4)
· · · |-Number(3)
· |-Add
· · |-Add
· · · |-Number(4)
· · · |-Number(3)
· · |-Add
· · · |-Number(4)
· · · |-Number(3)
```

With PR:
```
╙──Add
    ╟──Add
    ║   ╟──Add
    ║   ║   ╟──Number(4)
    ║   ║   ╙──Number(3)
    ║   ╙──Add
    ║       ╟──Number(4)
    ║       ╙──Number(3)
    ╙──Add
        ╟──Add
        ║   ╟──Number(4)
        ║   ╙──Number(3)
        ╙──Add
            ╟──Number(4)
            ╙──Number(3)
```