### PR TITLE
Evaluate UnionAll and CartesianProduct via RelationalCypherRecords

### DIFF
--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/io/EntityTable.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/io/EntityTable.scala
@@ -37,7 +37,7 @@ import org.opencypher.okapi.ir.api.block.{Asc, Desc, SortItem}
 import org.opencypher.okapi.ir.api.expr._
 import org.opencypher.okapi.ir.api.{Label, PropertyKey, RelType}
 import org.opencypher.okapi.relational.api.io.RelationalEntityMapping._
-import org.opencypher.okapi.relational.impl.physical.{Ascending, Descending, JoinType, Order}
+import org.opencypher.okapi.relational.impl.physical._
 import org.opencypher.okapi.relational.impl.table.RecordHeader
 
 trait FlatRelationalTable[T <: FlatRelationalTable[T]] extends CypherTable {

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/io/EntityTable.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/io/EntityTable.scala
@@ -172,7 +172,12 @@ trait RelationalCypherRecords[T <: FlatRelationalTable[T]] extends CypherRecords
   }
 
   def unionAll(other: R): R = {
-    val unionData = table.unionAll(other.table)
+    val orderedTable = if (table.physicalColumns != other.table.physicalColumns) {
+      other.table.select(table.physicalColumns: _*)
+    } else {
+      other.table
+    }
+    val unionData = table.unionAll(orderedTable)
     from(header, unionData)
   }
 

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/io/EntityTable.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/io/EntityTable.scala
@@ -172,8 +172,18 @@ trait RelationalCypherRecords[T <: FlatRelationalTable[T]] extends CypherRecords
   }
 
   def unionAll(other: R): R = {
-    val orderedTable = if (table.physicalColumns != other.table.physicalColumns) {
-      other.table.select(table.physicalColumns: _*)
+    val leftColumns = table.physicalColumns
+    val rightColumns = other.table.physicalColumns
+
+    if (leftColumns.size != rightColumns.size) {
+      throw IllegalArgumentException("same number of columns", s"left: $leftColumns right: $rightColumns")
+    }
+    if (leftColumns.toSet != rightColumns.toSet) {
+      throw IllegalArgumentException("same column names", s"left: $leftColumns right: $rightColumns")
+    }
+
+    val orderedTable = if (leftColumns != rightColumns) {
+      other.table.select(leftColumns: _*)
     } else {
       other.table
     }

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalConstants.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/physical/PhysicalConstants.scala
@@ -32,6 +32,7 @@ case object InnerJoin extends JoinType
 case object LeftOuterJoin extends JoinType
 case object RightOuterJoin extends JoinType
 case object FullOuterJoin extends JoinType
+case object CrossJoin extends JoinType
 
 sealed trait Order
 

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/table/RecordHeader.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/table/RecordHeader.scala
@@ -28,7 +28,6 @@ package org.opencypher.okapi.relational.impl.table
 
 import org.opencypher.okapi.api.types.{CTNode, CTNodeOrNull, CTRelationship, CTRelationshipOrNull}
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
-import org.opencypher.okapi.impl.util.StringEncodingUtilities._
 import org.opencypher.okapi.impl.util.TablePrinter
 import org.opencypher.okapi.ir.api.RelType
 import org.opencypher.okapi.ir.api.expr._

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/CAPSTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/CAPSTable.scala
@@ -78,7 +78,8 @@ object SparkCypherTable {
       df.where(expr.asSparkSQLExpr(header, df, parameters))
     }
 
-    override def withColumn(column: String, expr: Expr)(implicit header: RecordHeader, parameters: CypherMap): DataFrameTable = {
+    override def withColumn(column: String, expr: Expr)
+      (implicit header: RecordHeader, parameters: CypherMap): DataFrameTable = {
       df.withColumn(column, expr.asSparkSQLExpr(header, df, parameters))
     }
 
@@ -120,12 +121,11 @@ object SparkCypherTable {
             case (l, r) => df.col(l) === other.df.col(r)
           }.reduce((acc, expr) => acc && expr)
 
-          df.join(other.df, joinExpr, joinTypeString)
-//          // TODO: the join produced corrupt data when the previous operator was a cross. We work around that by using a
-//          // subsequent select. This can be removed, once https://issues.apache.org/jira/browse/SPARK-23855 is solved or we
-//          // upgrade to Spark 2.3.0
-//          val potentiallyCorruptedResult = df.join(other.df, joinExpr, joinTypeString)
-//          potentiallyCorruptedResult.select("*")
+          // TODO: the join produced corrupt data when the previous operator was a cross. We work around that by using a
+          // subsequent select. This can be removed, once https://issues.apache.org/jira/browse/SPARK-23855 is solved or we
+          // upgrade to Spark 2.3.0
+          val potentiallyCorruptedResult = df.join(other.df, joinExpr, joinTypeString)
+          potentiallyCorruptedResult.select("*")
       }
     }
 
@@ -174,7 +174,8 @@ case class CAPSNodeTable(
   override def from(
     header: RecordHeader,
     table: DataFrameTable,
-    columnNames: Option[Seq[String]] = None): CAPSNodeTable = CAPSNodeTable(mapping, table)
+    columnNames: Option[Seq[String]] = None
+  ): CAPSNodeTable = CAPSNodeTable(mapping, table)
 
   override private[spark] def entityType = mapping.cypherType
 }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/CAPSTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/CAPSTable.scala
@@ -120,11 +120,12 @@ object SparkCypherTable {
             case (l, r) => df.col(l) === other.df.col(r)
           }.reduce((acc, expr) => acc && expr)
 
-          // TODO: the join produced corrupt data when the previous operator was a cross. We work around that by using a
-          // subsequent select. This can be removed, once https://issues.apache.org/jira/browse/SPARK-23855 is solved or we
-          // upgrade to Spark 2.3.0
-          val potentiallyCorruptedResult = df.join(other.df, joinExpr, joinTypeString)
-          potentiallyCorruptedResult.select("*")
+          df.join(other.df, joinExpr, joinTypeString)
+//          // TODO: the join produced corrupt data when the previous operator was a cross. We work around that by using a
+//          // subsequent select. This can be removed, once https://issues.apache.org/jira/browse/SPARK-23855 is solved or we
+//          // upgrade to Spark 2.3.0
+//          val potentiallyCorruptedResult = df.join(other.df, joinExpr, joinTypeString)
+//          potentiallyCorruptedResult.select("*")
       }
     }
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSGraph.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSGraph.scala
@@ -115,13 +115,7 @@ trait CAPSGraph extends PropertyGraph with GraphOperations with Serializable {
   }
 
   protected def alignRecords(records: Seq[CAPSRecords], targetVar: Var, targetHeader: RecordHeader): Option[CAPSRecords] = {
-    // Align entity tables to target header
-    val alignedRecords = records.map(_.alignWith(targetVar, targetHeader))
-    // Ensure a consistent column order for the subsequent union
-    val selectExpressions = targetHeader.expressions.toSeq.sorted
-    val consistentRecords = alignedRecords.map(_.select(selectExpressions.head, selectExpressions.tail: _*))
-    // Union all entity tables
-    consistentRecords.reduceOption(_ unionAll _)
+    records.map(_.alignWith(targetVar, targetHeader)).reduceOption(_ unionAll _)
   }
 
 }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
@@ -170,14 +170,8 @@ final case class TabularUnionAll(lhs: CAPSPhysicalOperator, rhs: CAPSPhysicalOpe
 
   override def executeBinary(left: CAPSPhysicalResult, right: CAPSPhysicalResult)
     (implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
-    val leftData = left.records.df
-    // left and right have the same set of columns, but the order must also match
-    val rightData = right.records.df.select(leftData.columns.head, leftData.columns.tail: _*)
-
-    val unionedData = leftData.union(rightData)
-    val records = CAPSRecords(header, unionedData)(left.records.caps)
-
-    CAPSPhysicalResult(records, left.workingGraph, left.workingGraphName)
+    val unionRecords = left.records.unionAll(right.records)
+    CAPSPhysicalResult(unionRecords, left.workingGraph, left.workingGraphName)
   }
 }
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/physical/operators/BinaryOperators.scala
@@ -34,7 +34,7 @@ import org.opencypher.okapi.ir.api.expr.{Expr, Var, _}
 import org.opencypher.okapi.ir.api.set.SetPropertyItem
 import org.opencypher.okapi.ir.api.{PropertyKey, RelType}
 import org.opencypher.okapi.logical.impl.{ConstructedEntity, ConstructedNode, ConstructedRelationship, LogicalPatternGraph}
-import org.opencypher.okapi.relational.impl.physical.JoinType
+import org.opencypher.okapi.relational.impl.physical.{CrossJoin, JoinType}
 import org.opencypher.okapi.relational.impl.table.RecordHeader
 import org.opencypher.spark.api.{CAPSSession, Tags}
 import org.opencypher.spark.impl.CAPSGraph.EmptyGraph
@@ -179,15 +179,9 @@ final case class CartesianProduct(lhs: CAPSPhysicalOperator, rhs: CAPSPhysicalOp
   extends BinaryPhysicalOperator with PhysicalOperatorDebugging {
 
   override def executeBinary(left: CAPSPhysicalResult, right: CAPSPhysicalResult)(
-    implicit context: CAPSRuntimeContext
-  ): CAPSPhysicalResult = {
-
-    val data = left.records.df
-    val otherData = right.records.df
-    val newData = data.crossJoin(otherData)
-
-    val records = CAPSRecords(header, newData)(left.records.caps)
-    CAPSPhysicalResult(records, left.workingGraph, left.workingGraphName)
+    implicit context: CAPSRuntimeContext): CAPSPhysicalResult = {
+    val crossRecords = left.records.join(right.records, CrossJoin)
+    CAPSPhysicalResult(crossRecords, left.workingGraph, left.workingGraphName)
   }
 }
 


### PR DESCRIPTION
* the union now checks for the correct column order of the input records and reorders the right side only if necessary