### PR TITLE
Set next development version to 0.1.7-SNAPSHOT

### DIFF
--- a/licensecheck-config/pom.xml
+++ b/licensecheck-config/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-licensecheck-config</artifactId>

--- a/okapi-api/pom.xml
+++ b/okapi-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-api</artifactId>

--- a/okapi-ir/pom.xml
+++ b/okapi-ir/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-ir</artifactId>

--- a/okapi-logical/pom.xml
+++ b/okapi-logical/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-logical</artifactId>

--- a/okapi-neo4j-procedures/pom.xml
+++ b/okapi-neo4j-procedures/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-neo4j-procedures</artifactId>

--- a/okapi-relational/pom.xml
+++ b/okapi-relational/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-relational</artifactId>

--- a/okapi-tck/pom.xml
+++ b/okapi-tck/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-tck</artifactId>

--- a/okapi-testing/pom.xml
+++ b/okapi-testing/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-testing</artifactId>

--- a/okapi-trees/pom.xml
+++ b/okapi-trees/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>okapi-trees</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.opencypher</groupId>
   <artifactId>okapi</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>0.1.7-SNAPSHOT</version>
 
   <name>Okapi - openCypher query compilation API and pipeline</name>
   <packaging>pom</packaging>

--- a/spark-cypher-examples/pom.xml
+++ b/spark-cypher-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>spark-cypher-examples</artifactId>

--- a/spark-cypher-tck/pom.xml
+++ b/spark-cypher-tck/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>okapi</artifactId>
     <groupId>org.opencypher</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>spark-cypher-tck</artifactId>

--- a/spark-cypher-testing/pom.xml
+++ b/spark-cypher-testing/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>spark-cypher-testing</artifactId>

--- a/spark-cypher/pom.xml
+++ b/spark-cypher/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencypher</groupId>
     <artifactId>okapi</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>spark-cypher</artifactId>


### PR DESCRIPTION
This makes it smoother for the build system to build a release candidate; just replace the `SNAPSHOT` part with a date.