### PR TITLE
Fix bug where numbers would get automatically coerced to strings

### DIFF
--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/types/CypherTypesTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/types/CypherTypesTest.scala
@@ -77,6 +77,9 @@ class CypherTypesTest extends FunSpec with Matchers {
     CTList(CTInteger) couldBeSameTypeAs CTList(CTFloat) shouldBe false
     CTList(CTInteger) couldBeSameTypeAs CTList(CTAny) shouldBe true
     CTList(CTAny) couldBeSameTypeAs CTList(CTInteger) shouldBe true
+
+    CTNull couldBeSameTypeAs CTInteger.nullable shouldBe true
+    CTInteger.nullable couldBeSameTypeAs CTNull shouldBe true
   }
 
   it("joining with list of void") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ExpressionBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ExpressionBehaviour.scala
@@ -698,14 +698,14 @@ class ExpressionBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("can concat two properties") {
       val g = initGraph(
         """
-          |CREATE (:A {v: "Hello"})
-          |CREATE (:B {v: "World"})
+          |CREATE (:A {a: "Hello"})
+          |CREATE (:B {b: "World"})
         """.stripMargin)
 
       g.cypher(
         """
           |MATCH (a:A), (b:B)
-          |RETURN a.v + b.v AS hello
+          |RETURN a.a + b.b AS hello
         """.stripMargin).records.toMaps should equal(Bag(
         CypherMap("hello" -> "HelloWorld")
       ))
@@ -714,14 +714,14 @@ class ExpressionBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("can concat a string and an integer") {
       val g = initGraph(
         """
-          |CREATE (:A {v1: "Hello", v2: 42})
-          |CREATE (:B {v1: 42, v2: "Hello"})
+          |CREATE (:A {a1: "Hello", a2: 42})
+          |CREATE (:B {b1: 42, b2: "Hello"})
         """.stripMargin)
 
       g.cypher(
         """
           |MATCH (a:A), (b:B)
-          |RETURN a.v1 + b.v1 AS hello, a.v2 + b.v2 as world
+          |RETURN a.a1 + b.b1 AS hello, a.a2 + b.b2 as world
         """.stripMargin).records.toMaps should equal(Bag(
         CypherMap("hello" -> "Hello42", "world" -> "42Hello")
       ))
@@ -730,14 +730,14 @@ class ExpressionBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("can concat a string and a float") {
       val g = initGraph(
         """
-          |CREATE (:A {v1: "Hello", v2: 42.0})
-          |CREATE (:B {v1: 42.0, v2: "Hello"})
+          |CREATE (:A {a1: "Hello", a2: 42.0})
+          |CREATE (:B {b1: 42.0, b2: "Hello"})
         """.stripMargin)
 
       g.cypher(
         """
           |MATCH (a:A), (b:B)
-          |RETURN a.v1 + b.v1 AS hello, a.v2 + b.v2 as world
+          |RETURN a.a1 + b.b1 AS hello, a.a2 + b.b2 as world
         """.stripMargin).records.toMaps should equal(Bag(
         CypherMap("hello" -> "Hello42.0", "world" -> "42.0Hello")
       ))

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/convert/SparkConversions.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/convert/SparkConversions.scala
@@ -129,6 +129,7 @@ object SparkConversions {
     def toCypherType(nullable: Boolean = false): Option[CypherType] = {
       val result = dt match {
         case StringType => Some(CTString)
+        case IntegerType => Some(CTInteger)
         case LongType => Some(CTInteger)
         case BooleanType => Some(CTBoolean)
         case BinaryType => Some(CTAny)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -189,6 +189,10 @@ object SparkTable {
     }
 
     override def unionAll(other: DataFrameTable): DataFrameTable = {
+      if (df.schema != other.df.schema) {
+        throw IllegalArgumentException("Equal DataFrame schemas", s"${df.schema}\n\t${other.df.schema}")
+      }
+
       df.union(other.df)
     }
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -190,7 +190,7 @@ object SparkTable {
 
     override def unionAll(other: DataFrameTable): DataFrameTable = {
       df.schema.fields.zip(other.df.schema.fields).foreach {
-        case (StructField(leftName, leftType, _, _), StructField(rightName, rightType, _, _)) => {
+        case (StructField(leftName, leftType, _, _), StructField(rightName, rightType, _, _)) =>
           if (leftName != rightName) {
             throw IllegalArgumentException(
               "Equal column names for union all",
@@ -201,7 +201,6 @@ object SparkTable {
               "Equal column data types for union all (differing nullability is OK)",
               s"Left column: $leftName with type $leftType and right column: $rightName with type $rightType")
           }
-        }
       }
 
       df.union(other.df)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -27,7 +27,7 @@
 package org.opencypher.spark.impl.table
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{NullType, StructField}
 import org.apache.spark.storage.StorageLevel
 import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.api.value.CypherValue
@@ -189,13 +189,19 @@ object SparkTable {
     }
 
     override def unionAll(other: DataFrameTable): DataFrameTable = {
-      val thisNameTypeSchema = df.schema.map(f => f.name -> f.dataType)
-      val otherNameTypeSchema = other.df.schema.map(f => f.name -> f.dataType)
-
-      if (thisNameTypeSchema != otherNameTypeSchema) {
-        throw IllegalArgumentException(
-          "Equal DataFrame schemas (differing nullability is OK)",
-          s"${df.schema}\n\t${other.df.schema}")
+      df.schema.fields.zip(other.df.schema.fields).foreach {
+        case (StructField(leftName, leftType, _, _), StructField(rightName, rightType, _, _)) => {
+          if (leftName != rightName) {
+            throw IllegalArgumentException(
+              "Equal column names for union all",
+              s"Left column: $leftName and right column: $rightName")
+          }
+          if (leftType != NullType && rightType != NullType && leftType != rightType) {
+            throw IllegalArgumentException(
+              "Equal column data types for union all (differing nullability is OK)",
+              s"Left column: $leftName with type $leftType and right column: $rightName with type $rightType")
+          }
+        }
       }
 
       df.union(other.df)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -189,8 +189,13 @@ object SparkTable {
     }
 
     override def unionAll(other: DataFrameTable): DataFrameTable = {
-      if (df.schema != other.df.schema) {
-        throw IllegalArgumentException("Equal DataFrame schemas", s"${df.schema}\n\t${other.df.schema}")
+      val thisNameTypeSchema = df.schema.map(f => f.name -> f.dataType)
+      val otherNameTypeSchema = other.df.schema.map(f => f.name -> f.dataType)
+
+      if (thisNameTypeSchema != otherNameTypeSchema) {
+        throw IllegalArgumentException(
+          "Equal DataFrame schemas (differing nullability is OK)",
+          s"${df.schema}\n\t${other.df.schema}")
       }
 
       df.union(other.df)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -192,10 +192,10 @@ object SparkTable {
       val rightTypes = other.df.schema.fields.flatMap(_.toCypherType)
 
       leftTypes.zip(rightTypes).foreach {
-        case (leftType, rightType) if !leftType.couldBeSameTypeAs(rightType) =>
+        case (leftType, rightType) if !leftType.nullable.couldBeSameTypeAs(rightType.nullable) =>
           throw IllegalArgumentException(
             "Equal column data types for union all (differing nullability is OK)",
-            s"Left schema: ${df.schema}\n\tRight schema: ${other.df.schema}")
+            s"Left fields:  ${df.schema.fields.mkString(", ")}\n\tRight fields: ${other.df.schema.fields.mkString(", ")}")
         case _ =>
       }
 


### PR DESCRIPTION
The bug is due to UNION semantics in Spark, but we avoid this operation
by manually checking the DataFrame schemas before UNION.

Co-authored-by: Martin Junghanns <martin.junghanns@neotechnology.com>