### PR TITLE
Tree improvements

### DIFF
--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/CypherStatement.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/CypherStatement.scala
@@ -27,45 +27,46 @@
 package org.opencypher.okapi.ir.api
 
 import org.opencypher.okapi.ir.api.block.{Binds, Block}
+import org.opencypher.okapi.ir.api.expr.Expr
 
-sealed trait CypherStatement[E] extends Block[E] {
+sealed trait CypherStatement extends Block {
   def info: QueryInfo
 }
 
-final case class CypherQuery[E](
+final case class CypherQuery(
     info: QueryInfo,
-    model: QueryModel[E]
-) extends CypherStatement[E] {
-  override def after: List[Block[E]] = model.after
+    model: QueryModel
+) extends CypherStatement {
+  override def after: List[Block] = model.after
 
-  override def binds: Binds[E] = model.binds
+  override def binds: Binds = model.binds
 
-  override def where: Set[E] = model.where
+  override def where: Set[Expr] = model.where
 
   override def graph: IRGraph = model.graph
 }
 
-final case class CreateGraphStatement[E](
+final case class CreateGraphStatement(
     info: QueryInfo,
     graph: IRGraph,
-    innerQuery: CypherQuery[E]
-) extends CypherStatement[E] {
+    innerQuery: CypherQuery
+) extends CypherStatement {
 
-  override val after: List[Block[E]] = List(innerQuery)
+  override val after: List[Block] = List(innerQuery)
 
-  override def binds: Binds[E] = Binds.empty
+  override def binds: Binds = Binds.empty
 
-  override def where: Set[E] = Set.empty
+  override def where: Set[Expr] = Set.empty
 }
 
-final case class DeleteGraphStatement[E](
+final case class DeleteGraphStatement(
   info: QueryInfo,
   graph: IRGraph
-) extends CypherStatement[E] {
+) extends CypherStatement {
 
-  override val after: List[Block[E]] = List.empty
+  override val after: List[Block] = List.empty
 
-  override def binds: Binds[E] = Binds.empty
+  override def binds: Binds = Binds.empty
 
-  override def where: Set[E] = Set.empty
+  override def where: Set[Expr] = Set.empty
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/IRElement.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/IRElement.scala
@@ -32,7 +32,7 @@ import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.impl.io.SessionGraphDataSource
 import org.opencypher.okapi.ir.api.expr.Expr
 import org.opencypher.okapi.ir.api.pattern._
-import org.opencypher.okapi.ir.api.set.{SetItem, SetPropertyItem}
+import org.opencypher.okapi.ir.api.set.SetItem
 
 object IRField {
   def relTypes(field: IRField): Set[String] = field.cypherType match {
@@ -62,11 +62,11 @@ object IRCatalogGraph {
 
 final case class IRCatalogGraph(qualifiedGraphName: QualifiedGraphName, schema: Schema) extends IRGraph
 
-final case class IRPatternGraph[E](
+final case class IRPatternGraph(
   qualifiedGraphName: QualifiedGraphName,
   schema: Schema,
-  clones: Map[IRField, E],
-  creates: Pattern[E],
-  sets: List[SetItem[Expr]],
+  clones: Map[IRField, Expr],
+  creates: Pattern,
+  sets: List[SetItem],
   onGraphs: List[QualifiedGraphName]
 ) extends IRGraph

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/QueryModel.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/QueryModel.scala
@@ -27,21 +27,18 @@
 package org.opencypher.okapi.ir.api
 
 import org.opencypher.okapi.api.value.CypherValue._
-import org.opencypher.okapi.impl.exception.IllegalStateException
 import org.opencypher.okapi.ir.api.block._
+import org.opencypher.okapi.ir.api.expr.Expr
 
-import scala.annotation.tailrec
-import scala.collection.generic.CanBuildFrom
-
-final case class QueryModel[E](
-  result: ResultBlock[E],
+final case class QueryModel(
+  result: ResultBlock,
   parameters: CypherMap
-) extends Block[E] {
-  override def after: List[Block[E]] = result.after
+) extends Block {
+  override def after: List[Block] = result.after
 
-  override def binds: Binds[E] = result.binds
+  override def binds: Binds = result.binds
 
-  override def where: Set[E] = result.where
+  override def where: Set[Expr] = result.where
 
   override def graph: IRGraph = result.graph
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/AggregationBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/AggregationBlock.scala
@@ -26,18 +26,19 @@
  */
 package org.opencypher.okapi.ir.api.block
 
+import org.opencypher.okapi.ir.api.expr.Expr
 import org.opencypher.okapi.ir.api.{IRField, IRGraph}
 
-final case class AggregationBlock[E](
-    after: List[Block[E]],
-    binds: Aggregations[E],
+final case class AggregationBlock(
+    after: List[Block],
+    binds: Aggregations,
     group: Set[IRField],
     graph: IRGraph
-) extends BasicBlock[Aggregations[E], E](BlockType("aggregation")) {
+) extends BasicBlock[Aggregations](BlockType("aggregation")) {
 
-  override val where: Set[E] = Set.empty[E] // no filtering in aggregation blocks
+  override val where: Set[Expr] = Set.empty[Expr] // no filtering in aggregation blocks
 }
 
-final case class Aggregations[E](pairs: Set[(IRField, E)]) extends Binds[E] {
+final case class Aggregations(pairs: Set[(IRField, Expr)]) extends Binds {
   override def fields: Set[IRField] = pairs.map(_._1)
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/BasicBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/BasicBlock.scala
@@ -26,6 +26,6 @@
  */
 package org.opencypher.okapi.ir.api.block
 
-abstract class BasicBlock[B <: Binds[E], E](override val blockType: BlockType) extends Block[E] {
+abstract class BasicBlock[B <: Binds](override val blockType: BlockType) extends Block {
   override def binds: B
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/Block.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/Block.scala
@@ -26,18 +26,19 @@
  */
 package org.opencypher.okapi.ir.api.block
 
+import org.opencypher.okapi.ir.api.expr.Expr
 import org.opencypher.okapi.ir.api.{IRField, IRGraph}
 import org.opencypher.okapi.trees.AbstractTreeNode
 
-abstract class Block[E] extends AbstractTreeNode[Block[E]] {
-  def dependencies: Set[Block[E]] = children.flatMap(_.toSet).toSet
+abstract class Block extends AbstractTreeNode[Block] {
+  def dependencies: Set[Block] = children.flatMap(_.toSet).toSet
 
   def blockType: BlockType = BlockType(this.getClass.getSimpleName)
 
-  def after: List[Block[E]]
+  def after: List[Block]
 
-  def binds: Binds[E]
-  def where: Set[E]
+  def binds: Binds
+  def where: Set[Expr]
 
   def graph: IRGraph
 }
@@ -45,20 +46,20 @@ abstract class Block[E] extends AbstractTreeNode[Block[E]] {
 final case class BlockType(name: String)
 
 object Binds {
-  def empty[E]: Binds[E] = new Binds[E] {
+  def empty: Binds = new Binds {
     override def fields: Set[IRField] = Set.empty
   }
 }
 
-trait Binds[E] {
+trait Binds {
   def fields: Set[IRField]
 }
 
 object BlockWhere {
-  def unapply[E](block: Block[E]): Option[Set[E]] = Some(block.where)
+  def unapply(block: Block): Option[Set[Expr]] = Some(block.where)
 }
 
 object NoWhereBlock {
-  def unapply[E](block: Block[E]): Option[Block[E]] =
+  def unapply(block: Block): Option[Block] =
     if (block.where.isEmpty) Some(block) else None
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/MatchBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/MatchBlock.scala
@@ -27,12 +27,13 @@
 package org.opencypher.okapi.ir.api.block
 
 import org.opencypher.okapi.ir.api.IRGraph
+import org.opencypher.okapi.ir.api.expr.Expr
 import org.opencypher.okapi.ir.api.pattern.Pattern
 
-final case class MatchBlock[E](
-    after: List[Block[E]],
-    binds: Pattern[E],
-    where: Set[E] = Set.empty[E],
+final case class MatchBlock(
+    after: List[Block],
+    binds: Pattern,
+    where: Set[Expr] = Set.empty[Expr],
     optional: Boolean,
     graph: IRGraph
-) extends BasicBlock[Pattern[E], E](BlockType("match"))
+) extends BasicBlock[Pattern](BlockType("match"))

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/OrderAndSliceBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/OrderAndSliceBlock.scala
@@ -27,21 +27,22 @@
 package org.opencypher.okapi.ir.api.block
 
 import org.opencypher.okapi.ir.api.IRGraph
+import org.opencypher.okapi.ir.api.expr.Expr
 
-final case class OrderAndSliceBlock[E](
-    after: List[Block[E]],
-    orderBy: Seq[SortItem[E]],
-    skip: Option[E],
-    limit: Option[E],
+final case class OrderAndSliceBlock(
+    after: List[Block],
+    orderBy: Seq[SortItem],
+    skip: Option[Expr],
+    limit: Option[Expr],
     graph: IRGraph
-) extends BasicBlock[OrderedFields[E], E](BlockType("order-and-slice")) {
-  override val binds: OrderedFields[E] = OrderedFields[E]()
-  override def where: Set[E] = Set.empty[E]
+) extends BasicBlock[OrderedFields](BlockType("order-and-slice")) {
+  override val binds: OrderedFields = OrderedFields()
+  override def where: Set[Expr] = Set.empty[Expr]
 }
 
-sealed trait SortItem[E] {
-  def expr: E
+sealed trait SortItem {
+  def expr: Expr
 }
 
-final case class Asc[E](expr: E) extends SortItem[E]
-final case class Desc[E](expr: E) extends SortItem[E]
+final case class Asc(expr: Expr) extends SortItem
+final case class Desc(expr: Expr) extends SortItem

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/ProjectBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/ProjectBlock.scala
@@ -27,19 +27,20 @@
 package org.opencypher.okapi.ir.api.block
 
 import org.opencypher.okapi.ir.api._
+import org.opencypher.okapi.ir.api.expr.Expr
 
-final case class ProjectBlock[E](
-    after: List[Block[E]],
-    binds: Fields[E] = Fields[E](),
-    where: Set[E] = Set.empty[E],
+final case class ProjectBlock(
+    after: List[Block],
+    binds: Fields = Fields(),
+    where: Set[Expr] = Set.empty[Expr],
     graph: IRGraph,
     distinct: Boolean = false
-) extends BasicBlock[Fields[E], E](BlockType("project"))
+) extends BasicBlock[Fields](BlockType("project"))
 
-final case class Fields[E](items: Map[IRField, E] = Map.empty[IRField, E]) extends Binds[E] {
+final case class Fields(items: Map[IRField, Expr] = Map.empty[IRField, Expr]) extends Binds {
   override def fields: Set[IRField] = items.keySet
 }
 
 case object ProjectedFieldsOf {
-  def apply[E](entries: (IRField, E)*) = Fields(entries.toMap)
+  def apply(entries: (IRField, Expr)*) = Fields(entries.toMap)
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/ResultBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/ResultBlock.scala
@@ -27,41 +27,42 @@
 package org.opencypher.okapi.ir.api.block
 
 import org.opencypher.okapi.ir.api._
+import org.opencypher.okapi.ir.api.expr.Expr
 
-sealed trait ResultBlock[E] extends Block[E] {
-  override val where: Set[E] = Set.empty
+sealed trait ResultBlock extends Block {
+  override val where: Set[Expr] = Set.empty
 }
 
-final case class TableResultBlock[E](
-  after: List[Block[E]],
-  binds: OrderedFields[E],
+final case class TableResultBlock(
+  after: List[Block],
+  binds: OrderedFields,
   graph: IRGraph
-) extends ResultBlock[E] {
+) extends ResultBlock {
 
-  def select(fields: Set[IRField]): TableResultBlock[E] =
+  def select(fields: Set[IRField]): TableResultBlock =
     copy(binds = binds.select(fields))
 }
 
 object TableResultBlock {
-  def empty[E](graph: IRGraph) =
-    TableResultBlock(List.empty, OrderedFields[E](), graph)
+  def empty(graph: IRGraph) =
+    TableResultBlock(List.empty, OrderedFields(), graph)
 }
 
-final case class OrderedFields[E](orderedFields: List[IRField] = List.empty) extends Binds[E] {
+final case class OrderedFields(orderedFields: List[IRField] = List.empty) extends Binds {
   override def fields: Set[IRField] = orderedFields.toSet
 
-  def select(fields: Set[IRField]): OrderedFields[E] = copy(orderedFields = orderedFields.filter(fields.contains))
+  def select(fields: Set[IRField]): OrderedFields = copy(orderedFields = orderedFields.filter(fields.contains))
 }
 
 object OrderedFields {
-  def fieldsFrom[E](fields: IRField*): OrderedFields[E] = OrderedFields[E](fields.toList)
+  def fieldsFrom[E](fields: IRField*): OrderedFields = OrderedFields(fields.toList)
 
-  def unapplySeq(arg: OrderedFields[_]): Option[Seq[IRField]] = Some(arg.orderedFields)
+  def unapplySeq(arg: OrderedFields): Option[Seq[IRField]] = Some(arg.orderedFields)
 }
 
-final case class GraphResultBlock[E](
-  after: List[Block[E]],
+final case class GraphResultBlock(
+  after: List[Block],
   graph: IRGraph
-) extends ResultBlock[E] {
-  override val binds: Binds[E] = Binds.empty
+) extends ResultBlock {
+  override val binds: Binds = Binds.empty
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/SourceBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/SourceBlock.scala
@@ -27,11 +27,12 @@
 package org.opencypher.okapi.ir.api.block
 
 import org.opencypher.okapi.ir.api.IRGraph
+import org.opencypher.okapi.ir.api.expr.Expr
 
-case class SourceBlock[E](
+case class SourceBlock(
     graph: IRGraph
-) extends BasicBlock[Binds[E], E](BlockType("source")) {
-  override def where: Set[E] = Set.empty[E]
-  override val after: List[Block[E]] = List.empty
-  override val binds: Binds[E] = Binds.empty
+) extends BasicBlock[Binds](BlockType("source")) {
+  override def where: Set[Expr] = Set.empty[Expr]
+  override val after: List[Block] = List.empty
+  override val binds: Binds = Binds.empty
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/UnwindBlock.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/block/UnwindBlock.scala
@@ -26,16 +26,17 @@
  */
 package org.opencypher.okapi.ir.api.block
 
+import org.opencypher.okapi.ir.api.expr.Expr
 import org.opencypher.okapi.ir.api.{IRField, IRGraph}
 
-final case class UnwindBlock[E](
-    after: List[Block[E]],
-    binds: UnwoundList[E],
+final case class UnwindBlock(
+    after: List[Block],
+    binds: UnwoundList,
     graph: IRGraph
-) extends BasicBlock[UnwoundList[E], E](BlockType("unwind")) {
-  override def where: Set[E] = Set.empty[E] // never filters
+) extends BasicBlock[UnwoundList](BlockType("unwind")) {
+  override def where: Set[Expr] = Set.empty[Expr] // never filters
 }
 
-final case class UnwoundList[E](list: E, variable: IRField) extends Binds[E] {
+final case class UnwoundList(list: Expr, variable: IRField) extends Binds {
   override def fields: Set[IRField] = Set(variable)
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -939,7 +939,7 @@ case class NullLit(cypherType: CypherType = CTNull) extends Lit[Null] {
 
 // Pattern Predicate Expression
 
-final case class ExistsPatternExpr(targetField: Var, ir: CypherQuery[Expr])(val cypherType: CypherType = CTBoolean)
+final case class ExistsPatternExpr(targetField: Var, ir: CypherQuery)(val cypherType: CypherType = CTBoolean)
   extends Expr {
 
   override type This = ExistsPatternExpr

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/set/SetItem.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/set/SetItem.scala
@@ -26,12 +26,12 @@
  */
 package org.opencypher.okapi.ir.api.set
 
-import org.opencypher.okapi.ir.api.expr.Var
+import org.opencypher.okapi.ir.api.expr.{Expr, Var}
 
-sealed trait SetItem[E] {
+sealed trait SetItem {
   def variable: Var
 }
 
-case class SetLabelItem[E](variable: Var, labels: Set[String]) extends SetItem[E]
+case class SetLabelItem(variable: Var, labels: Set[String]) extends SetItem
 
-case class SetPropertyItem[E](propertyKey: String, variable: Var, setValue: E) extends SetItem[E]
+case class SetPropertyItem(propertyKey: String, variable: Var, setValue: Expr) extends SetItem

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/BlockRegistry.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/BlockRegistry.scala
@@ -29,15 +29,15 @@ package org.opencypher.okapi.ir.impl
 import org.opencypher.okapi.ir.api.block.Block
 
 object BlockRegistry {
-  def empty[E]: BlockRegistry[E] = BlockRegistry[E](List.empty)
+  def empty: BlockRegistry = BlockRegistry(List.empty)
 }
 
 // TODO: Inline in IRBuilderContext
-case class BlockRegistry[E](reg: List[Block[E]]) {
+case class BlockRegistry(reg: List[Block]) {
 
-  def register(blockDef: Block[E]): BlockRegistry[E] = {
+  def register(blockDef: Block): BlockRegistry = {
     copy(reg = reg :+ blockDef)
   }
 
-  def lastAdded: Option[Block[E]] = reg.lastOption
+  def lastAdded: Option[Block] = reg.lastOption
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/ExpressionConverter.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/ExpressionConverter.scala
@@ -123,7 +123,7 @@ final class ExpressionConverter(implicit context: IRBuilderContext) {
     // Exists (rewritten Pattern Expressions)
     case org.opencypher.okapi.ir.impl.parse.rewriter.ExistsPattern(subquery, trueVar) =>
       val innerModel = IRBuilder(subquery)(context) match {
-        case cq: CypherQuery[Expr] => cq
+        case cq: CypherQuery => cq
         case _ => throw new IllegalArgumentException("ExistsPattern only accepts SingleQuery")
       }
       ExistsPatternExpr(

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/IRBuilderContext.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/IRBuilderContext.scala
@@ -48,7 +48,7 @@ final case class IRBuilderContext(
   queryString: String,
   parameters: CypherMap,
   workingGraph: IRGraph, // initially the ambient graph, but gets changed by `FROM GRAPH`/`CONSTRUCT`
-  blockRegistry: BlockRegistry[Expr] = BlockRegistry.empty[Expr],
+  blockRegistry: BlockRegistry = BlockRegistry.empty,
   semanticState: SemanticState,
   queryCatalog: CatalogWithQuerySchemas, // copy of Session catalog plus constructed graph schemas
   knownTypes: Map[ast.Expression, CypherType] = Map.empty) {
@@ -57,7 +57,7 @@ final case class IRBuilderContext(
   private lazy val exprConverter = new ExpressionConverter()(self)
   private lazy val patternConverter = new PatternConverter()(self)
 
-  def convertPattern(p: ast.Pattern, qgn: Option[QualifiedGraphName] = None): Pattern[Expr] = {
+  def convertPattern(p: ast.Pattern, qgn: Option[QualifiedGraphName] = None): Pattern = {
     patternConverter.convert(p, knownTypes, qgn.getOrElse(workingGraph.qualifiedGraphName))
   }
 
@@ -82,7 +82,7 @@ final case class IRBuilderContext(
 
   def schemaFor(qgn: QualifiedGraphName): Schema = queryCatalog.schema(qgn)
 
-  def withBlocks(reg: BlockRegistry[Expr]): IRBuilderContext = copy(blockRegistry = reg)
+  def withBlocks(reg: BlockRegistry): IRBuilderContext = copy(blockRegistry = reg)
 
   def withFields(fields: Set[IRField]): IRBuilderContext = {
     val withFieldTypes = fields.foldLeft(knownTypes) {
@@ -109,8 +109,8 @@ object IRBuilderContext {
     sessionCatalog: Map[Namespace, PropertyGraphDataSource],
     fieldsFromDrivingTable: Set[Var] = Set.empty
   ): IRBuilderContext = {
-    val registry = BlockRegistry.empty[Expr]
-    val block = SourceBlock[Expr](workingGraph)
+    val registry = BlockRegistry.empty
+    val block = SourceBlock(workingGraph)
     val updatedRegistry = registry.register(block)
     val queryCatalog = CatalogWithQuerySchemas(sessionCatalog)
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/package.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/package.scala
@@ -33,7 +33,6 @@ import org.atnos.eff.syntax.all._
 import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.api.types.{CTNode, CTRelationship, CypherType}
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
-import org.opencypher.okapi.ir.api.expr.Expr
 
 package object impl {
 
@@ -55,7 +54,7 @@ package object impl {
   }
 
   def error[R: _mayFail : _hasContext, A](err: IRBuilderError)(v: A): Eff[R, A] =
-    left[R, IRBuilderError, BlockRegistry[Expr]](err) >> pure(v)
+    left[R, IRBuilderError, BlockRegistry](err) >> pure(v)
 
   implicit final class RichSchema(schema: Schema) {
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/rewriter/extractSubqueryFromPatternExpression.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/rewriter/extractSubqueryFromPatternExpression.scala
@@ -28,8 +28,8 @@ package org.opencypher.okapi.ir.impl.parse.rewriter
 
 import org.opencypher.v9_0.ast._
 import org.opencypher.v9_0.ast.semantics.{SemanticCheck, SemanticCheckResult, SemanticCheckableExpression}
-import org.opencypher.v9_0.expressions.functions.Exists
 import org.opencypher.v9_0.expressions._
+import org.opencypher.v9_0.expressions.functions.Exists
 import org.opencypher.v9_0.rewriting.rewriters.{nameMatchPatternElements, normalizeMatchPredicates}
 import org.opencypher.v9_0.util._
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/refactor/instances/ExprBlockInstances.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/refactor/instances/ExprBlockInstances.scala
@@ -45,12 +45,12 @@ trait ExprBlockInstances {
     }
   }
 
-  implicit def typedMatchBlock: TypedBlock[MatchBlock[Expr]] =
-    new TypedBlock[MatchBlock[Expr]] {
+  implicit def typedMatchBlock: TypedBlock[MatchBlock] =
+    new TypedBlock[MatchBlock] {
 
       override type BlockExpr = Expr
 
-      override def outputs(block: MatchBlock[Expr]): Set[IRField] = {
+      override def outputs(block: MatchBlock): Set[IRField] = {
         val opaqueTypedFields = block.binds.fields
         val predicates = block.where
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/refactor/syntax/BlockSyntax.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/refactor/syntax/BlockSyntax.scala
@@ -32,11 +32,11 @@ import org.opencypher.okapi.ir.api.block.Block
 import scala.language.implicitConversions
 
 trait BlockSyntax {
-  implicit def typedBlockOps[B <: Block[_], E](
+  implicit def typedBlockOps[B <: Block, E](
       block: B)(implicit instance: TypedBlock[B] { type BlockExpr = E }): TypedBlockOps[B, E] =
     new TypedBlockOps[B, E](block)
 }
 
-final class TypedBlockOps[B <: Block[_], E](block: B)(implicit instance: TypedBlock[B] { type BlockExpr = E }) {
+final class TypedBlockOps[B <: Block, E](block: B)(implicit instance: TypedBlock[B] { type BlockExpr = E }) {
   def outputs: Set[IRField] = instance.outputs(block)
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/typer/TypeTracker.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/typer/TypeTracker.scala
@@ -26,8 +26,8 @@
  */
 package org.opencypher.okapi.ir.impl.typer
 
-import org.opencypher.v9_0.expressions.Expression
 import org.opencypher.okapi.api.types.CypherType
+import org.opencypher.v9_0.expressions.Expression
 
 import scala.annotation.tailrec
 

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
@@ -870,7 +870,7 @@ class IrBuilderTest extends IrTestSuite {
            |}
         """.stripMargin
 
-      val result = query.parseIR[CreateGraphStatement[Expr]]()
+      val result = query.parseIR[CreateGraphStatement]()
 
       result.innerQuery.model should equalWithTracing(innerQuery.asCypherQuery().model)
       result.graph.qualifiedGraphName should equal(QualifiedGraphName(Namespace("session"), GraphName("bar")))
@@ -882,7 +882,7 @@ class IrBuilderTest extends IrTestSuite {
     it("can parse a DROP GRAPH statement") {
       val query = s"CATALOG DROP GRAPH $testQualifiedGraphName"
 
-      val result = query.parseIR[DeleteGraphStatement[Expr]]()
+      val result = query.parseIR[DeleteGraphStatement]()
 
       result.graph.qualifiedGraphName should equal(testQualifiedGraphName)
       result.graph.schema should equal(testGraphSchema)
@@ -1078,9 +1078,9 @@ class IrBuilderTest extends IrTestSuite {
     }
   }
 
-  implicit class RichBlock(b: Block[Expr]) {
+  implicit class RichBlock(b: Block) {
 
-    def findExactlyOne(f: PartialFunction[Block[Expr], Unit]): Block[Expr] = {
+    def findExactlyOne(f: PartialFunction[Block, Unit]): Block = {
       val results = b.collect {
         case block if f.isDefinedAt(block) =>
           f(block)
@@ -1093,9 +1093,9 @@ class IrBuilderTest extends IrTestSuite {
     }
   }
 
-  implicit class RichModel(model: QueryModel[Expr]) {
+  implicit class RichModel(model: QueryModel) {
 
-    def ensureThat(f: (QueryModel[Expr], CypherMap) => Unit): Unit = f(model, model.parameters)
+    def ensureThat(f: (QueryModel, CypherMap) => Unit): Unit = f(model, model.parameters)
 
   }
 

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrTestSuite.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrTestSuite.scala
@@ -45,50 +45,50 @@ abstract class IrTestSuite extends BaseTestSuite {
   def testGraph()(implicit schema: Schema = testGraphSchema) =
     IRCatalogGraph(testQualifiedGraphName, schema)
 
-  def leafBlock: SourceBlock[Expr] = SourceBlock[Expr](testGraph)
+  def leafBlock: SourceBlock = SourceBlock(testGraph)
 
-  val graphBlock: SourceBlock[Expr] = SourceBlock[Expr](testGraph)
+  val graphBlock: SourceBlock = SourceBlock(testGraph)
 
   def project(
-    fields: Fields[Expr],
-    after: List[Block[Expr]] = List(leafBlock),
-    given: Set[Expr] = Set.empty[Expr]) =
+    fields: Fields,
+    after: List[Block] = List(leafBlock),
+    given: Set[Expr] = Set.empty) =
     ProjectBlock(after, fields, given, testGraph)
 
-  protected def matchBlock(pattern: Pattern[Expr]): Block[Expr] =
-    MatchBlock[Expr](List(leafBlock), pattern, Set.empty[Expr], false, testGraph)
+  protected def matchBlock(pattern: Pattern): Block =
+    MatchBlock(List(leafBlock), pattern, Set.empty, false, testGraph)
 
-  def irFor(root: Block[Expr]): CypherQuery[Expr] = {
-    val result = TableResultBlock[Expr](
+  def irFor(root: Block): CypherQuery = {
+    val result = TableResultBlock(
       after = List(root),
-      binds = OrderedFields[Expr](),
+      binds = OrderedFields(),
       graph = testGraph
     )
     val model = QueryModel(result, CypherMap.empty)
     CypherQuery(QueryInfo("test"), model)
   }
 
-  case class DummyBlock[E](override val after: List[Block[E]] = List.empty) extends BasicBlock[DummyBinds[E], E](BlockType("dummy")) {
-    override def binds: DummyBinds[E] = DummyBinds[E]()
+  case class DummyBlock(override val after: List[Block] = List.empty) extends BasicBlock[DummyBinds[Expr]](BlockType("dummy")) {
+    override def binds: DummyBinds[Expr] = DummyBinds[Expr]()
 
-    override def where: Set[E] = Set.empty[E]
+    override def where: Set[Expr] = Set.empty[Expr]
 
     override val graph: IRCatalogGraph = testGraph
   }
 
-  case class DummyBinds[E](fields: Set[IRField] = Set.empty) extends Binds[E]
+  case class DummyBinds[E](fields: Set[IRField] = Set.empty) extends Binds
 
   implicit class RichString(queryText: String) {
-    def parseIR[T <: CypherStatement[Expr] : ClassTag](graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): T =
+    def parseIR[T <: CypherStatement : ClassTag](graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): T =
       ir(graphsWithSchema:_ *) match {
         case cq : T => cq
         case other => throw new IllegalArgumentException(s"Cannot convert $other")
     }
 
-    def asCypherQuery(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherQuery[Expr] =
-      parseIR[CypherQuery[Expr]](graphsWithSchema: _*)
+    def asCypherQuery(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherQuery =
+      parseIR[CypherQuery](graphsWithSchema: _*)
 
-    def ir(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherStatement[Expr] = {
+    def ir(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherStatement = {
       val stmt = CypherParser(queryText)(CypherParser.defaultContext)
       val parameters = Map.empty[String, CypherValue]
       IRBuilder(stmt)(
@@ -102,7 +102,7 @@ abstract class IrTestSuite extends BaseTestSuite {
         ))
     }
 
-    def irWithParams(params: (String, CypherValue)*)(implicit schema: Schema = Schema.empty): CypherStatement[Expr] = {
+    def irWithParams(params: (String, CypherValue)*)(implicit schema: Schema = Schema.empty): CypherStatement = {
       val stmt = CypherParser(queryText)(CypherParser.defaultContext)
       IRBuilder(stmt)(
         IRBuilderContext.initial(queryText,

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/PatternConverterTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/PatternConverterTest.scala
@@ -255,7 +255,7 @@ class PatternConverterTest extends IrTestSuite {
   }
   val converter = new PatternConverter()(IRBuilderHelper.emptyIRBuilderContext)
 
-  def convert(p: ast.Pattern, knownTypes: Map[ast.Expression, CypherType] = Map.empty): Pattern[Expr] =
+  def convert(p: ast.Pattern, knownTypes: Map[ast.Expression, CypherType] = Map.empty): Pattern =
     converter.convert(p, knownTypes, testQualifiedGraphName)
 
   def parse(exprText: String): ast.Pattern = PatternParser.parse(exprText, None)

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/block/TypedMatchBlockTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/block/TypedMatchBlockTest.scala
@@ -30,7 +30,6 @@ import org.opencypher.okapi.api.graph.QualifiedGraphName
 import org.opencypher.okapi.api.types.{CTNode, CTRelationship}
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.ir.api.block.MatchBlock
-import org.opencypher.okapi.ir.api.expr.Expr
 import org.opencypher.okapi.ir.impl.IrTestSuite
 import org.opencypher.okapi.ir.impl.refactor.instances._
 
@@ -70,13 +69,13 @@ class TypedMatchBlockTest extends IrTestSuite {
       ))
   }
 
-  private def matchBlock(singleMatchQuery: String): (MatchBlock[Expr], CypherMap) = {
+  private def matchBlock(singleMatchQuery: String): (MatchBlock, CypherMap) = {
     val model = singleMatchQuery.asCypherQuery().model
     val projectBlock = model.result.after.head
     val matchBlock = projectBlock.after.head
 
     matchBlock match {
-      case block: MatchBlock[Expr] =>
+      case block: MatchBlock =>
         block -> model.parameters
 
       case x => throw new MatchError(s"Supposed to be a match block, was: $x")

--- a/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/LogicalOperator.scala
+++ b/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/LogicalOperator.scala
@@ -74,7 +74,7 @@ case class LogicalPatternGraph(
   schema: Schema,
   clones: Map[Var, Var],
   newEntities: Set[ConstructedEntity],
-  sets: List[SetItem[Expr]],
+  sets: List[SetItem],
   onGraphs: List[QualifiedGraphName],
   qualifiedGraphName: QualifiedGraphName
 ) extends LogicalGraph {
@@ -268,7 +268,7 @@ final case class Select(
 final case class ReturnGraph(in: LogicalOperator, solved: SolvedQueryModel)
   extends StackingLogicalOperator with EmptyFields
 
-final case class OrderBy(sortItems: Seq[SortItem[Expr]], in: LogicalOperator, solved: SolvedQueryModel)
+final case class OrderBy(sortItems: Seq[SortItem], in: LogicalOperator, solved: SolvedQueryModel)
   extends StackingLogicalOperator {
 
   override val fields: Set[Var] = in.fields

--- a/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/LogicalOperatorProducer.scala
+++ b/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/LogicalOperatorProducer.scala
@@ -104,7 +104,7 @@ class LogicalOperatorProducer {
     ExistsSubQuery(expr, matchPlan, patternPlan, matchPlan.solved)
   }
 
-  def aggregate(aggregations: Aggregations[Expr], group: Set[IRField], prev: LogicalOperator): Aggregate = {
+  def aggregate(aggregations: Aggregations, group: Set[IRField], prev: LogicalOperator): Aggregate = {
     val transformed: Set[(Var, Aggregator)] = aggregations.pairs.collect { case (field, aggregator: Aggregator) => toVar(field) -> aggregator }
 
     Aggregate(transformed, group.map(toVar), prev, prev.solved.withFields(aggregations.fields.toSeq: _*))
@@ -145,7 +145,7 @@ class LogicalOperatorProducer {
     DrivingTable(graph, fields, SolvedQueryModel(irFields))
   }
 
-  def planOrderBy(sortItems: Seq[SortItem[Expr]], prev: LogicalOperator): OrderBy = {
+  def planOrderBy(sortItems: Seq[SortItem], prev: LogicalOperator): OrderBy = {
     OrderBy(sortItems, prev, prev.solved)
   }
 

--- a/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/SolvedQueryModel.scala
+++ b/okapi-logical/src/main/scala/org/opencypher/okapi/logical/impl/SolvedQueryModel.scala
@@ -36,7 +36,7 @@ import org.opencypher.okapi.ir.impl.util.VarConverters.toVar
 
 case class SolvedQueryModel(
   fields: Set[IRField],
-  predicates: Set[Expr] = Set.empty[Expr]
+  predicates: Set[Expr] = Set.empty
 ) {
 
   // extension
@@ -49,9 +49,9 @@ case class SolvedQueryModel(
     copy(fields ++ other.fields, predicates ++ other.predicates)
 
   // containment
-  def contains(blocks: Block[Expr]*): Boolean = contains(blocks.toSet)
-  def contains(blocks: Set[Block[Expr]]): Boolean = blocks.forall(contains)
-  def contains(block: Block[Expr]): Boolean = {
+  def contains(blocks: Block*): Boolean = contains(blocks.toSet)
+  def contains(blocks: Set[Block]): Boolean = blocks.forall(contains)
+  def contains(block: Block): Boolean = {
     val bindsFields = block.binds.fields subsetOf fields
     val preds = block.where subsetOf predicates
 
@@ -59,7 +59,7 @@ case class SolvedQueryModel(
   }
 
   def solves(f: IRField): Boolean = fields(f)
-  def solves(p: Pattern[Expr]): Boolean = p.fields.subsetOf(fields)
+  def solves(p: Pattern): Boolean = p.fields.subsetOf(fields)
 
   def solveRelationship(r: IRField): SolvedQueryModel = {
     r.cypherType match {

--- a/okapi-logical/src/test/scala/org/opencypher/okapi/logical/impl/IrConstruction.scala
+++ b/okapi-logical/src/test/scala/org/opencypher/okapi/logical/impl/IrConstruction.scala
@@ -45,9 +45,9 @@ trait IrConstruction {
   self: BaseTestSuite =>
 
   def project(
-    fields: Fields[Expr],
-    after: List[Block[Expr]] = List(leafBlock),
-    given: Set[Expr] = Set.empty[Expr]) =
+    fields: Fields,
+    after: List[Block] = List(leafBlock),
+    given: Set[Expr] = Set.empty) =
     ProjectBlock(after, fields, given, testGraph)
 
 
@@ -57,32 +57,32 @@ trait IrConstruction {
   protected def leafPlan: Start =
     Start(LogicalCatalogGraph(testGraph.qualifiedGraphName, testGraph.schema), SolvedQueryModel.empty)
 
-  protected def irFor(root: Block[Expr]): CypherQuery[Expr] = {
-    val result = TableResultBlock[Expr](
+  protected def irFor(root: Block): CypherQuery = {
+    val result = TableResultBlock(
       after = List(root),
-      binds = OrderedFields[Expr](),
+      binds = OrderedFields(),
       graph = testGraph
     )
     val model = QueryModel(result, CypherMap.empty)
     CypherQuery(QueryInfo("test"), model)
   }
 
-  protected def leafBlock: SourceBlock[Expr] = SourceBlock[Expr](testGraph)
+  protected def leafBlock: SourceBlock = SourceBlock(testGraph)
 
-  protected def matchBlock(pattern: Pattern[Expr]): Block[Expr] =
-    MatchBlock[Expr](List(leafBlock), pattern, Set.empty[Expr], false, testGraph)
+  protected def matchBlock(pattern: Pattern): Block =
+    MatchBlock(List(leafBlock), pattern, Set.empty, false, testGraph)
 
   implicit class RichString(queryText: String) {
-    def parseIR[T <: CypherStatement[Expr] : ClassTag](graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): T =
+    def parseIR[T <: CypherStatement : ClassTag](graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): T =
       ir(graphsWithSchema:_ *) match {
         case cq : T => cq
         case other => throw new IllegalArgumentException(s"Cannot convert $other")
       }
 
-    def asCypherQuery(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherQuery[Expr] =
-      parseIR[CypherQuery[Expr]](graphsWithSchema: _*)
+    def asCypherQuery(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherQuery =
+      parseIR[CypherQuery](graphsWithSchema: _*)
 
-    def ir(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherStatement[Expr] = {
+    def ir(graphsWithSchema: (GraphName, Schema)*)(implicit schema: Schema = Schema.empty): CypherStatement = {
       val stmt = CypherParser(queryText)(CypherParser.defaultContext)
       val parameters = Map.empty[String, CypherValue]
       IRBuilder(stmt)(
@@ -96,7 +96,7 @@ trait IrConstruction {
         ))
     }
 
-    def irWithParams(params: (String, CypherValue)*)(implicit schema: Schema = Schema.empty): CypherStatement[Expr] = {
+    def irWithParams(params: (String, CypherValue)*)(implicit schema: Schema = Schema.empty): CypherStatement = {
       val stmt = CypherParser(queryText)(CypherParser.defaultContext)
       IRBuilder(stmt)(
         IRBuilderContext.initial(queryText,

--- a/okapi-logical/src/test/scala/org/opencypher/okapi/logical/impl/SolvedQueryModelTest.scala
+++ b/okapi-logical/src/test/scala/org/opencypher/okapi/logical/impl/SolvedQueryModelTest.scala
@@ -57,7 +57,7 @@ class SolvedQueryModelTest extends BaseTestSuite with IrConstruction {
   test("contains several blocks") {
     val block1 = matchBlock(Pattern.empty.withEntity('a -> CTNode))
     val block2 = matchBlock(Pattern.empty.withEntity('b -> CTNode))
-    val binds: Fields[Expr] = Fields(Map(toField('c) -> Equals('a, 'b)(CTBoolean)))
+    val binds: Fields = Fields(Map(toField('c) -> Equals('a, 'b)(CTBoolean)))
     val block3 = project(binds)
     val block4 = project(ProjectedFieldsOf(toField('d) -> Equals('c, 'b)(CTBoolean)))
 
@@ -71,7 +71,7 @@ class SolvedQueryModelTest extends BaseTestSuite with IrConstruction {
 
   test("solves") {
     val s = SolvedQueryModel.empty.withField('a).withFields('b, 'c)
-    val p = Pattern.empty[Expr].withEntity('a -> CTNode).withEntity('b -> CTNode).withEntity('c -> CTNode)
+    val p = Pattern.empty.withEntity('a -> CTNode).withEntity('b -> CTNode).withEntity('c -> CTNode)
 
     s.solves(toField('a)) shouldBe true
     s.solves(toField('b)) shouldBe true

--- a/okapi-logical/src/test/scala/org/opencypher/okapi/logical/impl/logical/LogicalPlannerTest.scala
+++ b/okapi-logical/src/test/scala/org/opencypher/okapi/logical/impl/logical/LogicalPlannerTest.scala
@@ -61,7 +61,7 @@ class LogicalPlannerTest extends BaseTestSuite with IrConstruction {
 
   it("converts match block") {
     val pattern = Pattern
-      .empty[Expr]
+      .empty
       .withEntity(nodeA)
       .withEntity(nodeB)
       .withEntity(relR)
@@ -81,7 +81,7 @@ class LogicalPlannerTest extends BaseTestSuite with IrConstruction {
 
   it("converts cyclic match block") {
     val pattern = Pattern
-      .empty[Expr]
+      .empty
       .withEntity(nodeA)
       .withEntity(relR)
       .withConnection(relR, CyclicRelationship(nodeA))
@@ -96,7 +96,7 @@ class LogicalPlannerTest extends BaseTestSuite with IrConstruction {
   }
 
   it("converts project block") {
-    val fields = Fields[Expr](Map(toField('a) -> Property('n, PropertyKey("prop"))(CTFloat)))
+    val fields = Fields(Map(toField('a) -> Property('n, PropertyKey("prop"))(CTFloat)))
     val block = project(fields)
 
     val result = plan(irFor(block))
@@ -282,18 +282,18 @@ class LogicalPlannerTest extends BaseTestSuite with IrConstruction {
 
   private val planner = new LogicalPlanner(new LogicalOperatorProducer)
 
-  private def plan(ir: CypherStatement[Expr], schema: Schema = Schema.empty): LogicalOperator =
+  private def plan(ir: CypherStatement, schema: Schema = Schema.empty): LogicalOperator =
     plan(ir, schema, testGraphName -> schema)
 
   private def plan(
-    ir: CypherStatement[Expr],
+    ir: CypherStatement,
     ambientSchema: Schema,
     graphWithSchema: (GraphName, Schema)*
   ): LogicalOperator = {
     val withAmbientGraph = graphWithSchema :+ (testGraphName -> ambientSchema)
 
     ir match {
-      case cq: CypherQuery[Expr] =>
+      case cq: CypherQuery =>
         planner.process(cq)(LogicalPlannerContext(ambientSchema, Set.empty, Map(testNamespace -> graphSource(withAmbientGraph: _*))))
       case _ => throw new IllegalArgumentException("Query is not a CypherQuery")
     }

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/graph/RelationalCypherGraph.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/graph/RelationalCypherGraph.scala
@@ -37,11 +37,15 @@ import org.opencypher.okapi.relational.impl.graph.{EmptyGraph, SingleTableGraph,
 import org.opencypher.okapi.relational.impl.operators.RelationalOperator
 import org.opencypher.okapi.relational.impl.planning.RelationalPlanner._
 
+import scala.reflect.runtime.universe.TypeTag
+
 trait RelationalCypherGraphFactory[T <: Table[T]] {
 
   type Graph = RelationalCypherGraph[T]
 
   implicit val session: RelationalCypherSession[T]
+
+  private[opencypher] implicit def tableTypeTag: TypeTag[T] = session.tableTypeTag
 
   def singleTableGraph(drivingTable: RelationalOperator[T], schema: Schema, tagsUsed: Set[Int])
     (implicit context: RelationalRuntimeContext[T]): Graph = new SingleTableGraph(drivingTable, schema, tagsUsed)
@@ -63,6 +67,8 @@ trait RelationalCypherGraph[T <: Table[T]] extends PropertyGraph {
   type Session <: RelationalCypherSession[T]
 
   override def session: Session
+
+  private[opencypher] implicit def tableTypeTag: TypeTag[T] = session.tableTypeTag
 
   def tags: Set[Int]
 

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/graph/RelationalCypherSession.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/graph/RelationalCypherSession.scala
@@ -32,9 +32,13 @@ import org.opencypher.okapi.relational.api.planning.RelationalRuntimeContext
 import org.opencypher.okapi.relational.api.table.{RelationalCypherRecordsFactory, Table}
 import org.opencypher.okapi.relational.impl.RelationalConverters._
 
-trait RelationalCypherSession[T <: Table[T]] extends CypherSession {
+import scala.reflect.runtime.universe.TypeTag
+
+abstract class RelationalCypherSession[T <: Table[T] : TypeTag] extends CypherSession {
 
   type Graph <: RelationalCypherGraph[T]
+
+  private[opencypher] val tableTypeTag: TypeTag[T] = implicitly[TypeTag[T]]
 
   private[opencypher] def records: RelationalCypherRecordsFactory[T]
 

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/RelationalConverters.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/RelationalConverters.scala
@@ -31,12 +31,14 @@ import org.opencypher.okapi.impl.exception.UnsupportedOperationException
 import org.opencypher.okapi.relational.api.graph.RelationalCypherGraph
 import org.opencypher.okapi.relational.api.table.Table
 
+import scala.reflect.runtime.universe.TypeTag
+
 object RelationalConverters {
 
-  implicit class RichPropertyGraph[T <: Table[T]](val graph: PropertyGraph) extends AnyVal {
-    def asRelational: RelationalCypherGraph[T] = graph.asInstanceOf[RelationalCypherGraph[_]] match {
+  implicit class RichPropertyGraph(val graph: PropertyGraph) extends AnyVal {
+    def asRelational[T <: Table[T] : TypeTag]: RelationalCypherGraph[T] = graph.asInstanceOf[RelationalCypherGraph[_]] match {
       // The cast is necessary since okapi-API does not expose the underlying table types
-      case caps: RelationalCypherGraph[T] => caps.asInstanceOf[RelationalCypherGraph[T]]
+      case caps: RelationalCypherGraph[_] => caps.asInstanceOf[RelationalCypherGraph[T]]
       case _ => throw UnsupportedOperationException(s"can only handle relational graphs, got $graph")
     }
   }

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/graph/ScanGraph.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/graph/ScanGraph.scala
@@ -38,7 +38,9 @@ import org.opencypher.okapi.relational.api.table.{RelationalCypherRecords, Table
 import org.opencypher.okapi.relational.impl.operators._
 import org.opencypher.okapi.relational.impl.planning.RelationalPlanner._
 
-class ScanGraph[T <: Table[T]](val scans: Seq[EntityTable[T]], val schema: Schema, val tags: Set[Int])
+import scala.reflect.runtime.universe.TypeTag
+
+class ScanGraph[T <: Table[T] : TypeTag](val scans: Seq[EntityTable[T]], val schema: Schema, val tags: Set[Int])
   (implicit val session: RelationalCypherSession[T])
   extends RelationalCypherGraph[T] {
 

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/graph/SingleTableGraph.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/graph/SingleTableGraph.scala
@@ -38,13 +38,15 @@ import org.opencypher.okapi.relational.api.table.{RelationalCypherRecords, Table
 import org.opencypher.okapi.relational.impl.operators._
 import org.opencypher.okapi.relational.impl.planning.RelationalPlanner._
 
+import scala.reflect.runtime.universe.TypeTag
+
 /**
   * A single table graph represents the result of CONSTRUCT clause. It contains all entities from the outer scope that
   * the clause constructs. The initial schema of that graph is the union of all graph schemata the CONSTRUCT clause refers
   * to, including their corresponding graph tags. Note, that the initial schema does not include the graph tag used for
   * the constructed entities.
   */
-class SingleTableGraph[T <: Table[T]](
+class SingleTableGraph[T <: Table[T] : TypeTag](
   val drivingTableOp: RelationalOperator[T],
   override val schema: Schema,
   override val tags: Set[Int]

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/graph/UnionGraph.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/graph/UnionGraph.scala
@@ -36,8 +36,10 @@ import org.opencypher.okapi.relational.api.table.{RelationalCypherRecords, Table
 import org.opencypher.okapi.relational.impl.operators.{Distinct, RelationalOperator, TabularUnionAll}
 import org.opencypher.okapi.relational.impl.planning.RelationalPlanner._
 
+import scala.reflect.runtime.universe.TypeTag
+
 // TODO: This should be a planned tree of physical operators instead of a graph
-final case class UnionGraph[T <: Table[T]](graphsToReplacements: Map[RelationalCypherGraph[T], Map[Int, Int]])
+final case class UnionGraph[T <: Table[T] : TypeTag](graphsToReplacements: Map[RelationalCypherGraph[T], Map[Int, Int]])
   (implicit context: RelationalRuntimeContext[T]) extends RelationalCypherGraph[T] {
 
   override implicit val session: RelationalCypherSession[T] = context.session

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/planning/VarLengthExpandPlanner.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/impl/planning/VarLengthExpandPlanner.scala
@@ -37,11 +37,13 @@ import org.opencypher.okapi.relational.impl.planning.RelationalPlanner.{process,
 import org.opencypher.okapi.relational.impl.table.RecordHeader
 import org.opencypher.okapi.relational.impl.{operators => relational}
 
+import scala.reflect.runtime.universe.TypeTag
+
 trait ExpandDirection
 case object Outbound extends ExpandDirection
 case object Inbound extends ExpandDirection
 
-trait VarLengthExpandPlanner[T <: Table[T]] {
+abstract class VarLengthExpandPlanner[T <: Table[T] : TypeTag] {
 
   def source: Var
 
@@ -112,7 +114,9 @@ trait VarLengthExpandPlanner[T <: Table[T]] {
     val nextEdgeCT = if (i > lower) edgeScan.cypherType.nullable else edgeScan.cypherType
     val nextEdge = ListSegment(i, list)(nextEdgeCT)
 
-    val aliasedEdgeScanOp = physicalEdgeScanOp.alias(edgeScan as nextEdge).select(nextEdge)
+    val aliasedEdgeScanOp = physicalEdgeScanOp.
+      alias(edgeScan as nextEdge)
+      .select(nextEdge)
 
     val iterationTableHeader = iterationTable.header
     val nextEdgeScanHeader = aliasedEdgeScanOp.header
@@ -227,7 +231,7 @@ trait VarLengthExpandPlanner[T <: Table[T]] {
 }
 
 // TODO: use object instead
-class DirectedVarLengthExpandPlanner[T <: Table[T]](
+class DirectedVarLengthExpandPlanner[T <: Table[T] : TypeTag](
   override val source: Var,
   override val list: Var,
   override val edgeScan: Var,
@@ -254,10 +258,11 @@ class DirectedVarLengthExpandPlanner[T <: Table[T]](
 
     finalize(withTargetOps)
   }
+
 }
 
 // TODO: use object instead
-class UndirectedVarLengthExpandPlanner[T <: Table[T]](
+class UndirectedVarLengthExpandPlanner[T <: Table[T] : TypeTag](
   override val source: Var,
   override val list: Var,
   override val edgeScan: Var,
@@ -301,4 +306,5 @@ class UndirectedVarLengthExpandPlanner[T <: Table[T]](
 
     finalize(withTargetOps)
   }
+
 }

--- a/okapi-trees/src/main/scala/org/opencypher/okapi/trees/TreeNode.scala
+++ b/okapi-trees/src/main/scala/org/opencypher/okapi/trees/TreeNode.scala
@@ -26,13 +26,14 @@
  */
 package org.opencypher.okapi.trees
 
+import cats.data.NonEmptyList
+
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.reflect.runtime.{currentMirror, universe}
 import scala.reflect.runtime.universe._
 import scala.util.hashing.MurmurHash3
-
 import scala.language.existentials
 
 /**
@@ -192,6 +193,11 @@ abstract class TreeNode[T <: TreeNode[T] : ClassTag] extends Product with Traver
                 case _: T => false
                 case _ => true
               }
+            }
+          case nel: NonEmptyList[_] =>
+            nel.exists {
+              case _: T => false
+              case _ => true
             }
           case a: Array[_] =>
             if (a.isEmpty) {

--- a/okapi-trees/src/test/scala/org/opencypher/okapi/trees/TreeNodeTest.scala
+++ b/okapi-trees/src/test/scala/org/opencypher/okapi/trees/TreeNodeTest.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.okapi.trees
 
-import cats.data
 import cats.data.NonEmptyList
 import org.scalatest.{FunSpec, Matchers}
 
@@ -62,41 +61,20 @@ class TreeNodeTest extends FunSpec with Matchers {
     addList2.eval should equal(6)
     val addList3 =
       AddList(NonEmptyList.one(1), Number(0), 2, NonEmptyList.one(Number(2)), NonEmptyList.of[Object]("a", "b"))
-        .withNewChildren(Array(1, 2, 3, 4, 5, 6, 7).map(Number(_)))
+        .withNewChildren(Array(1, 2, 3, 4, 5, 6, 7).map(Number))
     addList3 should equal(AddList(NonEmptyList.one(1), Number(1), 2, NonEmptyList.of(2, 3, 4, 5, 6, 7).map(Number), NonEmptyList.of[Object]("a", "b")))
     addList3.eval should equal(28)
   }
 
-  it("unsupported uses of lists of children") {
+  it("unsupported uses of automatically detected children") {
     // Test errors when violating list requirements
 
     intercept[IllegalArgumentException] {
       val fail = AddList(NonEmptyList.one(1), Number(1), 2, NonEmptyList.one(Number(2)), NonEmptyList.of[Object]("a", "b"))
       fail.children.toSet should equal(Set(Number(1), Number(2)))
       fail.withNewChildren(Array(Number(1)))
-    }.getMessage should equal("requirement failed: a list of children cannot be empty.")
+    }.getMessage should equal("Cannot create NonEmptyList from empty list")
 
-    // - if any children are contained in a list at all, then all list elements need to be children
-    intercept[InvalidConstructorArgument] {
-      val fail = Unsupported(data.NonEmptyList.of(UnsupportedLeaf, "2"))
-      fail.show()
-    }.getMessage should equal(
-      s"""Expected a list that contains either no children or only children
-         |but found a mixed list that contains a child as the head element,
-         |but also one with a non-child type: java.lang.String cannot be cast to ${classOf[AbstractTreeNode[_]].getName}.
-         |""".stripMargin)
-
-    // - there can be at most one list of children
-    intercept[IllegalArgumentException] {
-      UnsupportedNode(NonEmptyList.one(UnsupportedLeaf), NonEmptyList.one(UnsupportedLeaf))
-    }.getMessage should equal("requirement failed: there can be at most one list of children in the constructor.")
-
-    // - there can be no normal child constructor parameters after the list of children
-    intercept[IllegalArgumentException] {
-      UnsupportedNode2(NonEmptyList.one(UnsupportedLeaf2), UnsupportedLeaf2)
-    }.getMessage should equal(
-      "requirement failed: there can be no normal child constructor parameters " +
-        "after a list of children.")
   }
 
   it("rewrite") {
@@ -161,7 +139,7 @@ class TreeNodeTest extends FunSpec with Matchers {
     val highTree = (1 to height).foldLeft(Number(1): CalcExpr) {
       case (t, n) => Add(t, Number(n))
     }
-    val simplified = BottomUpStackSafe[CalcExpr] {
+    BottomUpStackSafe[CalcExpr] {
       case Add(Number(n1), Number(n2)) => Number(n1 + n2)
     }.transform(highTree)
 
@@ -179,8 +157,7 @@ class TreeNodeTest extends FunSpec with Matchers {
     Add(Number(1), Number(2)).argString should equal("")
   }
 
-  // TODO: Requires type tags to detect child types. For now just filtering empty collections and options from args.
-  ignore("option and list arg string") {
+  it("option and list arg string") {
     Dummy(None, List.empty, None, List.empty).argString should equal("print1=None, print2=List()")
   }
 
@@ -211,7 +188,10 @@ class TreeNodeTest extends FunSpec with Matchers {
 
   case object UnsupportedLeaf extends UnsupportedTree
 
-  case class UnsupportedNode(elems1: NonEmptyList[UnsupportedTree], elems2: NonEmptyList[UnsupportedTree]) extends UnsupportedTree
+  case class UnsupportedNode(
+    elems1: NonEmptyList[UnsupportedTree],
+    elems2: NonEmptyList[UnsupportedTree]
+  ) extends UnsupportedTree
 
   abstract class UnsupportedTree2 extends AbstractTreeNode[UnsupportedTree2]
 
@@ -223,11 +203,22 @@ class TreeNodeTest extends FunSpec with Matchers {
     def eval: Int
   }
 
-  case class Dummy(print1: Option[String], print2: List[String], dontPrint1: Option[CalcExpr], dontPrint2: List[CalcExpr]) extends CalcExpr {
+  case class Dummy(
+    print1: Option[String],
+    print2: List[String],
+    dontPrint1: Option[CalcExpr],
+    dontPrint2: List[CalcExpr]
+  ) extends CalcExpr {
     def eval = 0
   }
 
-  case class AddList(dummy1: NonEmptyList[Int], first: CalcExpr, dummy2: Int, remaining: NonEmptyList[CalcExpr], dummy3: NonEmptyList[Object])
+  case class AddList(
+    dummy1: NonEmptyList[Int],
+    first: CalcExpr,
+    dummy2: Int,
+    remaining: NonEmptyList[CalcExpr],
+    dummy3: NonEmptyList[Object]
+  )
     extends CalcExpr {
     def eval: Int = first.eval + remaining.map(_.eval).toList.sum
   }
@@ -243,5 +234,54 @@ class TreeNodeTest extends FunSpec with Matchers {
   case class NoOp(in: CalcExpr) extends CalcExpr {
     def eval: Int = in.eval
   }
+
+
+  it("can infer children for complex case classes") {
+    val instance = Multi(
+      NonEmptyList.one(1),
+      NonEmptyList.of(SimpleA(), SimpleA()),
+      List("A", "B"),
+      List(SimpleB(), SimpleB()),
+      Some(1L),
+      None,
+      Some(SimpleD())
+    )
+
+    instance.children.toList should equal(List(
+      SimpleA(), SimpleA(), SimpleB(), SimpleB(), SimpleD()
+    ))
+
+    instance.withNewChildren(Array(
+      SimpleA(), SimpleC()
+    )) should equal(Multi(
+      NonEmptyList.one(1),
+      NonEmptyList.of(SimpleA()),
+      List("A", "B"),
+      List(),
+      Some(1L),
+      Some(SimpleC()),
+      None
+    ))
+  }
+
+  abstract class ComplexExample extends AbstractTreeNode[ComplexExample]
+
+  case class SimpleA() extends ComplexExample
+
+  case class SimpleB() extends ComplexExample
+
+  case class SimpleC() extends ComplexExample
+
+  case class SimpleD() extends ComplexExample
+
+  case class Multi(
+    ints: NonEmptyList[Integer],
+    as: NonEmptyList[SimpleA],
+    s: List[String],
+    bs: List[SimpleB],
+    maybeL: Option[Long],
+    maybeC: Option[SimpleC],
+    maybeD: Option[SimpleD]
+  ) extends ComplexExample
 
 }

--- a/okapi-trees/src/test/scala/org/opencypher/okapi/trees/TreeNodeTest.scala
+++ b/okapi-trees/src/test/scala/org/opencypher/okapi/trees/TreeNodeTest.scala
@@ -264,7 +264,45 @@ class TreeNodeTest extends FunSpec with Matchers {
     ))
   }
 
+  it("fails with an understandable error message when running out of children to assign") {
+    val instance = ListBeforeFixed(List.empty, SimpleA())
+
+    instance.children.toList should equal(List(
+      SimpleA()
+    ))
+
+    intercept[IllegalArgumentException] {
+      instance.withNewChildren(Array(
+        SimpleA(), SimpleA()
+      ))
+    }.getMessage should equal(
+      """|When updating with new children: Did not have a child left to assign to the child that was previously SimpleA
+         |Inferred constructor parameters so far: ListBeforeFixed(List(SimpleA, SimpleA), ...)""".stripMargin)
+  }
+
+  it("fails with an understandable error message when there are children left over after assignment to constructor arguments") {
+    val instance = SimpleList(List(SimpleA()))
+
+    instance.children.toList should equal(List(
+      SimpleA()
+    ))
+
+    intercept[IllegalArgumentException] {
+      instance.withNewChildren(Array(
+        SimpleA(), SimpleB()
+      ))
+    }.getMessage should equal(
+      """|Could not assign children [SimpleB] to parameters of SimpleList
+         |Inferred constructor parameters: SimpleList(List(SimpleA))""".stripMargin)
+  }
+
   abstract class ComplexExample extends AbstractTreeNode[ComplexExample]
+
+  // All a's get assigned to the list
+  case class ListBeforeFixed(as: List[SimpleA], a: SimpleA) extends ComplexExample
+
+  // All a's get assigned to the list
+  case class SimpleList(as: List[SimpleA]) extends ComplexExample
 
   case class SimpleA() extends ComplexExample
 

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/CAPSGraphTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/CAPSGraphTest.scala
@@ -29,6 +29,7 @@ package org.opencypher.spark.impl
 import org.apache.spark.sql.Row
 import org.opencypher.okapi.api.io.conversion.RelationshipMapping
 import org.opencypher.okapi.api.types._
+import org.opencypher.okapi.relational.api.planning.RelationalRuntimeContext
 import org.opencypher.okapi.relational.api.table.RelationalCypherRecords
 import org.opencypher.okapi.relational.impl.operators.Start
 import org.opencypher.okapi.testing.Bag
@@ -38,6 +39,8 @@ import org.opencypher.spark.impl.table.SparkTable.DataFrameTable
 import org.opencypher.spark.testing.CAPSTestSuite
 import org.opencypher.spark.testing.fixture.{GraphConstructionFixture, RecordsVerificationFixture, TeamDataFixture}
 
+import scala.reflect.runtime.universe
+
 abstract class CAPSGraphTest extends CAPSTestSuite
   with GraphConstructionFixture
   with RecordsVerificationFixture
@@ -45,7 +48,11 @@ abstract class CAPSGraphTest extends CAPSTestSuite
 
   object CAPSGraphTest {
     implicit class RecordOps(records: RelationalCypherRecords[DataFrameTable]) {
-      def planStart: Start[DataFrameTable] = Start(records)(caps.basicRuntimeContext())
+      def planStart: Start[DataFrameTable] = {
+        implicit val tableTypeTag: universe.TypeTag[DataFrameTable] = caps.tableTypeTag
+        implicit val context: RelationalRuntimeContext[DataFrameTable] = caps.basicRuntimeContext()
+        Start(records)
+      }
     }
   }
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/CAPSSession.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/CAPSSession.scala
@@ -43,7 +43,7 @@ import org.opencypher.spark.impl.{CAPSRecords, CAPSRecordsFactory, CAPSSessionIm
 
 import scala.reflect.runtime.universe._
 
-trait CAPSSession extends RelationalCypherSession[DataFrameTable] {
+abstract class CAPSSession extends RelationalCypherSession[DataFrameTable] {
 
   protected implicit val caps: CAPSSession = this
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSSessionImpl.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/CAPSSessionImpl.scala
@@ -39,7 +39,7 @@ import org.opencypher.okapi.impl.io.SessionGraphDataSource
 import org.opencypher.okapi.impl.util.Measurement.printTiming
 import org.opencypher.okapi.ir.api._
 import org.opencypher.okapi.ir.api.configuration.IrConfiguration.PrintIr
-import org.opencypher.okapi.ir.api.expr.{Expr, Var}
+import org.opencypher.okapi.ir.api.expr.Var
 import org.opencypher.okapi.ir.impl.parse.CypherParser
 import org.opencypher.okapi.ir.impl.{IRBuilder, IRBuilderContext}
 import org.opencypher.okapi.logical.api.configuration.LogicalConfiguration.PrintLogicalPlan
@@ -52,7 +52,7 @@ import org.opencypher.spark.api.CAPSSession
 import org.opencypher.spark.impl.CAPSConverters._
 import org.opencypher.spark.impl.table.SparkTable.DataFrameTable
 
-sealed class CAPSSessionImpl(val sparkSession: SparkSession) extends CAPSSession with Serializable {
+sealed class CAPSSessionImpl(val sparkSession: SparkSession) extends CAPSSession {
 
   override type Result = RelationalCypherResult[DataFrameTable]
 
@@ -100,7 +100,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession) extends CAPSSession
     }
 
     ir match {
-      case cq: CypherQuery[Expr] =>
+      case cq: CypherQuery =>
         planCypherQuery(graph, cq, allParameters, inputFields, maybeCapsRecords)
 
       case CreateGraphStatement(_, targetGraph, innerQueryIr) =>
@@ -133,7 +133,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession) extends CAPSSession
 
   private def planCypherQuery(
     graph: PropertyGraph,
-    cypherQuery: CypherQuery[Expr],
+    cypherQuery: CypherQuery,
     allParameters: CypherMap,
     inputFields: Set[Var],
     maybeDrivingTable: Option[RelationalCypherRecords[DataFrameTable]]
@@ -142,7 +142,7 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession) extends CAPSSession
     planRelational(maybeDrivingTable, allParameters, logicalPlan)
   }
 
-  private def planLogical(ir: CypherQuery[Expr], graph: PropertyGraph, inputFields: Set[Var]) = {
+  private def planLogical(ir: CypherQuery, graph: PropertyGraph, inputFields: Set[Var]) = {
     logStageProgress("Logical planning ...", newLine = false)
     val logicalPlannerContext = LogicalPlannerContext(graph.schema, inputFields, catalog.listSources)
     val logicalPlan = time("Logical planning")(logicalPlanner(ir)(logicalPlannerContext))
@@ -206,4 +206,5 @@ sealed class CAPSSessionImpl(val sparkSession: SparkSession) extends CAPSSession
   }
 
   override def toString: String = s"${this.getClass.getSimpleName}"
+
 }


### PR DESCRIPTION
Supports improved children detection:
```scala
  abstract class ComplexExample extends AbstractTreeNode[ComplexExample]

  case class SimpleA() extends ComplexExample

  case class SimpleB() extends ComplexExample

  case class SimpleC() extends ComplexExample

  case class SimpleD() extends ComplexExample

  case class Multi(
    ints: NonEmptyList[Integer],
    as: NonEmptyList[SimpleA],
    s: List[String],
    bs: List[SimpleB],
    maybeL: Option[Long],
    maybeC: Option[SimpleC],
    maybeD: Option[SimpleD]
  ) extends ComplexExample

it("can infer children for complex case classes") {
    val instance = Multi(
      NonEmptyList.one(1),
      NonEmptyList.of(SimpleA(), SimpleA()),
      List("A", "B"),
      List(SimpleB(), SimpleB()),
      Some(1L),
      None,
      Some(SimpleD())
    )

    instance.children.toList should equal(List(
      SimpleA(), SimpleA(), SimpleB(), SimpleB(), SimpleD()
    ))

    instance.withNewChildren(Array(
      SimpleA(), SimpleC()
    )) should equal(Multi(
      NonEmptyList.one(1),
      NonEmptyList.of(SimpleA()),
      List("A", "B"),
      List(),
      Some(1L),
      Some(SimpleC()),
      None
    ))
  }
```