### PR TITLE
Add schema patterns (node edge node) to Schema

### DIFF
--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/Schema.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/Schema.scala
@@ -30,6 +30,7 @@ import org.opencypher.okapi.api.schema.LabelPropertyMap._
 import org.opencypher.okapi.api.schema.PropertyKeys.PropertyKeys
 import org.opencypher.okapi.api.schema.RelTypePropertyMap._
 import org.opencypher.okapi.api.types.{CTRelationship, CypherType}
+import org.opencypher.okapi.impl.annotations.experimental
 import org.opencypher.okapi.impl.schema.SchemaImpl._
 import org.opencypher.okapi.impl.schema.{ImpliedLabels, LabelCombinations, SchemaImpl}
 
@@ -86,12 +87,14 @@ trait Schema {
     *
     * @return schema pattern combinations encoded in this schema
     */
+  @experimental
   def schemaPatterns: Set[SchemaPattern]
 
   /**
     * Retrieves the user defined schema patterns
     * @return user defines schema patterns
     */
+  @experimental
   def explicitSchemaPatterns: Set[SchemaPattern]
 
   /**
@@ -207,6 +210,7 @@ trait Schema {
     * @param knownTargetLabels labels required for the target node (AND semantics)
     * @return schema patterns that fulfill the predicates
     */
+  @experimental
   def schemaPatternsFor(knownSourceLabels: Set[String], knownRelTypes: Set[String], knownTargetLabels: Set[String]): Set[SchemaPattern]
 
   /**
@@ -279,6 +283,7 @@ trait Schema {
     * @param patterns the patterns to add
     * @return schema with added explicit schema patterns
     */
+  @experimental
   def withSchemaPatterns(patterns: SchemaPattern*): Schema
 
   /**

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/Schema.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/Schema.scala
@@ -74,6 +74,15 @@ trait Schema {
     */
   def relTypePropertyMap: RelTypePropertyMap
 
+
+  def schemaPatterns: Set[SchemaPattern]
+
+  /**
+    * Retrieves the user defined schema patterns
+    * @return user defines schema patterns
+    */
+  def explicitSchemaPatterns: Set[SchemaPattern]
+
   /**
     * Implied labels for each existing label.
     */
@@ -172,6 +181,8 @@ trait Schema {
     */
   def relationshipKeys(typ: String): PropertyKeys
 
+  def schemaPatternsFor(knownSourceLabels: Set[String], knownRelTypes: Set[String], knownTargetLabels: Set[String]): Set[SchemaPattern]
+
   /**
     * Adds information about a label and its associated properties to the schema.
     * The arguments provided to this method are interpreted as describing a whole piece of information,
@@ -231,6 +242,8 @@ trait Schema {
     */
   def withRelationshipPropertyKeys(typ: String)(keys: (String, CypherType)*): Schema =
     withRelationshipPropertyKeys(typ, keys.toMap)
+
+  def withSchemaPatterns(patterns: SchemaPattern*): Schema
 
   /**
     * Returns the union of the input schemas.

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/Schema.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/Schema.scala
@@ -74,7 +74,18 @@ trait Schema {
     */
   def relTypePropertyMap: RelTypePropertyMap
 
-
+  /**
+    * Returns all schema patterns known to this schema.
+    * A schema pattern is a constraint over a (node)-[relationship]->(node) pattern which describes possible label and
+    * relationship type combinations for the source node, the relationship and the target node in the pattern.
+    *
+    * If no explicit schema patterns are defined, this function will return schema patterns for all possible combinations
+    * between the known label combinations and relationship types. Otherwise only explicit schema patterns will be returned.
+    *
+    * @see {{{org.opencypher.okapi.api.schema.SchemaPattern}}} for more information
+    *
+    * @return schema pattern combinations encoded in this schema
+    */
   def schemaPatterns: Set[SchemaPattern]
 
   /**
@@ -181,6 +192,21 @@ trait Schema {
     */
   def relationshipKeys(typ: String): PropertyKeys
 
+  /**
+    * This function returns all schema patterns that are applicable with regards to the specified known labels and
+    * relationship types. The given labels and relationship types are interpreted similar to how a Cypher MATCH clause
+    * would interpret them. That is, the label sets are interpreted as a conjunction of label predicates, i.e. labels
+    * the node must have. The relationship types are interpreted as a disjunction, i.e. the relationship must have
+    * one of the given types.
+    *
+    * All the schema patterns that match the given descriptions will be retrieved. In particular, if all the inputs are
+    * empty sets, all the schema patterns will be retrieved.
+    *
+    * @param knownSourceLabels labels required for the source node (AND semantics)
+    * @param knownRelTypes relationship types possible for the relationship (OR semantics)
+    * @param knownTargetLabels labels required for the target node (AND semantics)
+    * @return schema patterns that fulfill the predicates
+    */
   def schemaPatternsFor(knownSourceLabels: Set[String], knownRelTypes: Set[String], knownTargetLabels: Set[String]): Set[SchemaPattern]
 
   /**
@@ -243,6 +269,16 @@ trait Schema {
   def withRelationshipPropertyKeys(typ: String)(keys: (String, CypherType)*): Schema =
     withRelationshipPropertyKeys(typ, keys.toMap)
 
+  /**
+    * Adds the given schema patterns to the explicitly defined schema patterns.
+    *
+    * @note If at least one explicit schema pattern has been defined, only explicit schema patterns will be considered
+    *       part of this schema.
+    * @see {{{org.opencypher.okapi.api.schema.Schema#schemaPatterns}}}
+    *
+    * @param patterns the patterns to add
+    * @return schema with added explicit schema patterns
+    */
   def withSchemaPatterns(patterns: SchemaPattern*): Schema
 
   /**

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
@@ -31,7 +31,7 @@ object SchemaPattern{
     sourceLabel: String,
     relType: String,
     targetLabel: String
-  ): SchemaPattern = new SchemaPattern(Set(sourceLabel), relType, Set(targetLabel))
+  ): SchemaPattern = SchemaPattern(Set(sourceLabel), relType, Set(targetLabel))
 }
 
 /**

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
 package org.opencypher.okapi.api.schema
 
 object SchemaPattern{

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
@@ -1,0 +1,85 @@
+package org.opencypher.okapi.api.schema
+
+object SchemaPattern{
+  def apply(
+    sourceLabel: String,
+    relType: String,
+    targetLabel: String
+  ): SchemaPattern = new SchemaPattern(Set(sourceLabel), relType, Set(targetLabel))
+}
+
+case class SchemaPattern(sourceLabels: Set[String], relType: String, targetLabels: Set[String]) {
+
+}
+
+//trait Cardinality
+//case object Any extends Cardinality
+//case object AtLeastOne extends Cardinality
+//case object ExactlyOne extends Cardinality
+//case class Between(from: Int, to: Int) extends Cardinality
+//
+//case class RelationshipConstraint(
+//  startNodeLabelCombo: Set[String],
+//  endNodeLabelCombo: Set[String],
+//  startNodeCardinality: Cardinality,
+//  endNodeCardinality: Cardinality
+//) {
+//
+//  def hasOverlap(other: RelationshipConstraint): Boolean = {
+//    startNodeLabelCombo.subsetOf(other.startNodeLabelCombo) || other.startNodeLabelCombo.subsetOf(startNodeLabelCombo)
+//    endNodeLabelCombo.subsetOf(other.endNodeLabelCombo) || other.endNodeLabelCombo.subsetOf(endNodeLabelCombo)
+//  }
+//
+//
+//  def isSubTypeOf(other: RelationshipConstraint): Boolean = {
+//    val startContained = startNodeLabelCombo.forall(other.startNodeLabelCombo.contains)
+//    val endContained = endNodeLabelCombo.forall(other.endNodeLabelCombo.contains)
+//
+//    (startContained, endContained match {
+//      case (true, true) =>
+//    })
+//  }
+//}
+//
+//object RelationshipConstraints {
+//  type RelationshipConstraints = Map[String, Set[RelationshipConstraint]]
+//
+//  implicit class RichRelationshipConstraint(map: RelationshipConstraints) {
+//
+//    def register(relType: String, constraint: RelationshipConstraint): RelationshipConstraints = {
+//      val existing = map.getOrElse(relType, Set.empty)
+//
+//      // TODO what to do when there are cardinality conflicts?
+//      map.updated(relType, existing + constraint)
+//    }
+//
+//    def ++(other: RelationshipConstraints): RelationshipConstraints = {
+//      val conflicts = map.keySet intersect other.keySet
+//
+//      conflicts.map { relType =>
+//        val lhs = map(relType)
+//        val rhs = map(relType)
+//
+//        lhs.
+//      }
+//    }
+//  }
+//}
+
+
+// (A, B), (A), (B), (C), (D), (D, E)
+//
+
+// Closed World
+// (A, B) -[:REL]-> (C) ++ (A, C) -[:REL]-> (D) => no conflict (A, B) -[:REL]-> (C), (A, C) -[:REL]-> (D)
+// (A, B) -[:REL]-> (C) ++ (A, B) -[:REL]-> (D) => no conflict (A, B) -[:REL]-> (C|D) or (A, B) -[:REL]-> (C), (A, B) -[:REL]-> (D)
+
+// Open World
+// (A) -> (C)
+// ()-[:REL]->(:B)
+
+
+// possibleLabels(Option(N), Option(E), Option(N)): Set[Constraint]
+// MATCH (:B)<-[:REL]-() =>
+
+

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/schema/SchemaPattern.scala
@@ -8,78 +8,27 @@ object SchemaPattern{
   ): SchemaPattern = new SchemaPattern(Set(sourceLabel), relType, Set(targetLabel))
 }
 
+/**
+  * Describes a (node)-[relationship]->(node) triple in a graph as part of the graph's schema.
+  * A pattern only applies to nodes with the exact label combination defined by `source/targetLabels`
+  * and relationships with the specified relationship type.
+  *
+  * @example Given a graph that only contains the following patterns
+  *                        {{{(:A)-[r1:REL]->(:C),}}}
+  *                        {{{(:B)-[r2:REL]->(:C),}}}
+  *                        {{{(:A:B)-[r3:REL]->(:C)}}}
+  *
+  *          then the schema pattern `SchemaPattern(Set("A"), "REL", Set("C"))` would only apply to `r1`
+  *          and the schema pattern `SchemaPattern(Set("A", "B"), "REL", Set("C"))` would only apply to `r3`
+  *
+  * @param sourceLabels label combination for source nodes
+  * @param relType relationship type
+  * @param targetLabels label combination for target nodes
+  */
 case class SchemaPattern(sourceLabels: Set[String], relType: String, targetLabels: Set[String]) {
-
+  override def toString: String = {
+    val sourceLabelString = if(sourceLabels.isEmpty) "" else sourceLabels.mkString(":", ":", "")
+    val targetLabelString = if(targetLabels.isEmpty) "" else targetLabels.mkString(":", ":", "")
+    s"($sourceLabelString)-[:$relType]->($targetLabelString)"
+  }
 }
-
-//trait Cardinality
-//case object Any extends Cardinality
-//case object AtLeastOne extends Cardinality
-//case object ExactlyOne extends Cardinality
-//case class Between(from: Int, to: Int) extends Cardinality
-//
-//case class RelationshipConstraint(
-//  startNodeLabelCombo: Set[String],
-//  endNodeLabelCombo: Set[String],
-//  startNodeCardinality: Cardinality,
-//  endNodeCardinality: Cardinality
-//) {
-//
-//  def hasOverlap(other: RelationshipConstraint): Boolean = {
-//    startNodeLabelCombo.subsetOf(other.startNodeLabelCombo) || other.startNodeLabelCombo.subsetOf(startNodeLabelCombo)
-//    endNodeLabelCombo.subsetOf(other.endNodeLabelCombo) || other.endNodeLabelCombo.subsetOf(endNodeLabelCombo)
-//  }
-//
-//
-//  def isSubTypeOf(other: RelationshipConstraint): Boolean = {
-//    val startContained = startNodeLabelCombo.forall(other.startNodeLabelCombo.contains)
-//    val endContained = endNodeLabelCombo.forall(other.endNodeLabelCombo.contains)
-//
-//    (startContained, endContained match {
-//      case (true, true) =>
-//    })
-//  }
-//}
-//
-//object RelationshipConstraints {
-//  type RelationshipConstraints = Map[String, Set[RelationshipConstraint]]
-//
-//  implicit class RichRelationshipConstraint(map: RelationshipConstraints) {
-//
-//    def register(relType: String, constraint: RelationshipConstraint): RelationshipConstraints = {
-//      val existing = map.getOrElse(relType, Set.empty)
-//
-//      // TODO what to do when there are cardinality conflicts?
-//      map.updated(relType, existing + constraint)
-//    }
-//
-//    def ++(other: RelationshipConstraints): RelationshipConstraints = {
-//      val conflicts = map.keySet intersect other.keySet
-//
-//      conflicts.map { relType =>
-//        val lhs = map(relType)
-//        val rhs = map(relType)
-//
-//        lhs.
-//      }
-//    }
-//  }
-//}
-
-
-// (A, B), (A), (B), (C), (D), (D, E)
-//
-
-// Closed World
-// (A, B) -[:REL]-> (C) ++ (A, C) -[:REL]-> (D) => no conflict (A, B) -[:REL]-> (C), (A, C) -[:REL]-> (D)
-// (A, B) -[:REL]-> (C) ++ (A, B) -[:REL]-> (D) => no conflict (A, B) -[:REL]-> (C|D) or (A, B) -[:REL]-> (C), (A, B) -[:REL]-> (D)
-
-// Open World
-// (A) -> (C)
-// ()-[:REL]->(:B)
-
-
-// possibleLabels(Option(N), Option(E), Option(N)): Set[Constraint]
-// MATCH (:B)<-[:REL]-() =>
-
-

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/annotations/experimental.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/annotations/experimental.scala
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
 package org.opencypher.okapi.impl.annotations
 
 import scala.annotation.StaticAnnotation

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/annotations/experimental.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/annotations/experimental.scala
@@ -1,0 +1,9 @@
+package org.opencypher.okapi.impl.annotations
+
+import scala.annotation.StaticAnnotation
+
+/**
+  * Experimental methods and classes are not subject to semantic versioning. They might thus be changed or
+  * removed at any time.
+  */
+final class experimental extends StaticAnnotation

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/schema/SchemaImpl.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/schema/SchemaImpl.scala
@@ -366,6 +366,14 @@ final case class SchemaImpl(
         builder.append(s"no relationship types$EOL")
       }
 
+      if (explicitSchemaPatterns.nonEmpty) {
+        builder.append(s"Explicit schema patterns {$EOL")
+        explicitSchemaPatterns.foreach( p =>
+          builder.append(s"\t$p$EOL")
+        )
+        builder.append(s"}$EOL")
+      }
+
       builder.toString
     }
 

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/schema/SchemaImpl.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/schema/SchemaImpl.scala
@@ -36,6 +36,7 @@ import org.opencypher.okapi.api.types.CypherType.joinMonoid
 import org.opencypher.okapi.api.types.{CypherType, _}
 import org.opencypher.okapi.impl.exception.SchemaException
 import org.opencypher.okapi.impl.schema.SchemaImpl._
+import ujson.Js.Obj
 import upickle.Js
 import upickle.default.{macroRW, _}
 
@@ -60,7 +61,11 @@ object SchemaImpl {
     json => {
       val labelPropertyMap = readJs[LabelPropertyMap](json.obj(LABEL_PROPERTY_MAP))
       val relTypePropertyMap = readJs[RelTypePropertyMap](json.obj(REL_TYPE_PROPERTY_MAP))
-      val explicitSchemaPatterns = readJs[Set[SchemaPattern]](json.obj(SCHEMA_PATTERNS))
+      val explicitSchemaPatterns = json.value match {
+        case Obj(v) if v.keySet.contains(SCHEMA_PATTERNS) => readJs[Set[SchemaPattern]](json.obj(SCHEMA_PATTERNS))
+        case _ => Set.empty[SchemaPattern]
+      }
+
       SchemaImpl(labelPropertyMap, relTypePropertyMap, explicitSchemaPatterns)
     }
   )

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/schema/SchemaImpl.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/schema/SchemaImpl.scala
@@ -61,8 +61,8 @@ object SchemaImpl {
     json => {
       val labelPropertyMap = readJs[LabelPropertyMap](json.obj(LABEL_PROPERTY_MAP))
       val relTypePropertyMap = readJs[RelTypePropertyMap](json.obj(REL_TYPE_PROPERTY_MAP))
-      val explicitSchemaPatterns = json.value match {
-        case Obj(v) if v.keySet.contains(SCHEMA_PATTERNS) => readJs[Set[SchemaPattern]](json.obj(SCHEMA_PATTERNS))
+      val explicitSchemaPatterns = json match {
+        case Obj(m) if m.keySet.contains(SCHEMA_PATTERNS) => readJs[Set[SchemaPattern]](json.obj(SCHEMA_PATTERNS))
         case _ => Set.empty[SchemaPattern]
       }
 

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/SchemaTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/SchemaTest.scala
@@ -429,6 +429,7 @@ class SchemaTest extends FunSpec with Matchers {
     val schema = Schema.empty
       .withRelationshipPropertyKeys("FOO")("p" -> CTString)
       .withNodePropertyKeys("BAR")("q" -> CTInteger)
+      .withSchemaPatterns(SchemaPattern(Set("BAR"), "FOO", Set("BAR")))
 
     val serialized = schema.toJson
 
@@ -451,6 +452,17 @@ class SchemaTest extends FunSpec with Matchers {
          |            "properties": {
          |                "p": "STRING"
          |            }
+         |        }
+         |    ],
+         |    "schemaPatterns": [
+         |        {
+         |            "sourceLabels": [
+         |                "BAR"
+         |            ],
+         |            "relType": "FOO",
+         |            "targetLabels": [
+         |                "BAR"
+         |            ]
          |        }
          |    ]
          |}""".stripMargin)

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/SchemaTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/SchemaTest.scala
@@ -27,6 +27,7 @@
 package org.opencypher.okapi.api.schema
 
 import org.opencypher.okapi.api.types._
+import org.opencypher.okapi.impl.exception.SchemaException
 import org.scalatest.{FunSpec, Matchers}
 
 class SchemaTest extends FunSpec with Matchers {
@@ -400,6 +401,30 @@ class SchemaTest extends FunSpec with Matchers {
     )
   }
 
+  it("concatenates explicit schema patterns") {
+    val schema1 = Schema.empty
+      .withNodePropertyKeys("Foo")()
+      .withRelationshipPropertyKeys("REL")()
+      .withSchemaPatterns(SchemaPattern("Foo", "REL", "Foo"))
+
+    val schema2 = Schema.empty
+      .withNodePropertyKeys("Bar")()
+      .withRelationshipPropertyKeys("REL")()
+      .withSchemaPatterns(SchemaPattern("Bar", "REL", "Bar"))
+
+    val schemaSum = schema1 ++ schema2
+
+    schemaSum should equal(
+      Schema.empty
+        .withNodePropertyKeys("Foo")()
+        .withRelationshipPropertyKeys("REL")()
+        .withNodePropertyKeys("Bar")()
+        .withRelationshipPropertyKeys("REL")()
+        .withSchemaPatterns(SchemaPattern("Foo", "REL", "Foo"))
+        .withSchemaPatterns(SchemaPattern("Bar", "REL", "Bar"))
+    )
+  }
+
   it("serializes to/from json") {
     val schema = Schema.empty
       .withRelationshipPropertyKeys("FOO")("p" -> CTString)
@@ -433,6 +458,177 @@ class SchemaTest extends FunSpec with Matchers {
     val deserialized = Schema.fromJson(serialized)
 
     deserialized should equal(schema)
+  }
+
+  describe("pattern schemas") {
+    it("is empty if the schema is empty") {
+      val schema = Schema.empty
+      schema.schemaPatterns shouldBe empty
+    }
+
+    it("is empty if there are no relationships") {
+      val schema = Schema.empty.withNodePropertyKeys("A")()
+      schema.schemaPatterns shouldBe empty
+    }
+
+    it("is empty if there are no nodes") {
+      val schema = Schema.empty.withRelationshipPropertyKeys("A")()
+      schema.schemaPatterns shouldBe empty
+    }
+
+    it("gives all the inferred patterns") {
+      val schema = Schema.empty
+        .withNodePropertyKeys("A")()
+        .withNodePropertyKeys("B")()
+        .withRelationshipPropertyKeys("REL")()
+
+      schema.schemaPatterns should equal(Set(
+        SchemaPattern(Set("A"), "REL", Set("A")),
+        SchemaPattern(Set("A"), "REL", Set("B")),
+        SchemaPattern(Set("B"), "REL", Set("A")),
+        SchemaPattern(Set("B"), "REL", Set("B"))
+      ))
+    }
+
+    it("returns the explicit patterns if any were given") {
+      val schema = Schema.empty
+        .withNodePropertyKeys("A")()
+        .withNodePropertyKeys("B")()
+        .withRelationshipPropertyKeys("REL")()
+        .withSchemaPatterns(SchemaPattern("A", "REL", "B"))
+
+      schema.schemaPatterns should equal(Set(
+        SchemaPattern("A", "REL", "B")
+      ))
+    }
+
+    it("throws a SchemaException when adding a schema pattern into an empty schema") {
+      a[SchemaException] should be thrownBy {
+        Schema.empty.withSchemaPatterns(SchemaPattern("A", "REL", "B"))
+      }
+    }
+
+    it("throws a SchemaException when adding a schema pattern for unknown start node labels") {
+      a[SchemaException] should be thrownBy {
+        Schema.empty
+          .withNodePropertyKeys("A")()
+          .withRelationshipPropertyKeys("REL")()
+          .withSchemaPatterns(SchemaPattern("A", "REL", "B"))
+      }
+    }
+
+    it("throws a SchemaException when adding a schema pattern for unknown end node labels") {
+      a[SchemaException] should be thrownBy {
+        Schema.empty
+          .withNodePropertyKeys("B")()
+          .withRelationshipPropertyKeys("REL")()
+          .withSchemaPatterns(SchemaPattern("A", "REL", "B"))
+      }
+    }
+
+    it("throws a SchemaException when adding a schema pattern for unknown rel type") {
+      a[SchemaException] should be thrownBy {
+        Schema.empty
+          .withNodePropertyKeys("A")()
+          .withNodePropertyKeys("B")()
+          .withSchemaPatterns(SchemaPattern("A", "REL", "B"))
+      }
+    }
+  }
+
+  describe("schemaPatternsFor") {
+    val aRel1B = SchemaPattern("A", "REL1", "B")
+    val aRel2CD = SchemaPattern(Set("A"), "REL2", Set("C", "D"))
+    val bRel2CD = SchemaPattern(Set("B"), "REL2", Set("C", "D"))
+    val CDRel1A = SchemaPattern(Set("C", "D"), "REL1", Set("A"))
+    val emptyRel1Empty = SchemaPattern(Set.empty[String], "REL1", Set.empty[String])
+
+    val schema = Schema.empty
+      .withNodePropertyKeys("A")()
+      .withNodePropertyKeys("B")()
+      .withNodePropertyKeys("C", "D")()
+      .withNodePropertyKeys()()
+      .withRelationshipPropertyKeys("REL1")()
+      .withRelationshipPropertyKeys("REL2")()
+      .withSchemaPatterns(aRel1B)
+      .withSchemaPatterns(aRel2CD)
+      .withSchemaPatterns(bRel2CD)
+      .withSchemaPatterns(CDRel1A)
+      .withSchemaPatterns(emptyRel1Empty)
+
+    it("works when nothing is known") {
+      schema.schemaPatternsFor(Set.empty, Set.empty, Set.empty) should equal(Set(
+        aRel1B,
+        aRel2CD,
+        bRel2CD,
+        CDRel1A,
+        emptyRel1Empty
+      ))
+    }
+
+    it("works when only the source node label is known") {
+      schema.schemaPatternsFor(Set.empty, Set.empty, Set.empty) should equal(Set(
+        aRel1B,
+        aRel2CD,
+        bRel2CD,
+        CDRel1A,
+        emptyRel1Empty
+      ))
+
+      schema.schemaPatternsFor(Set("A"), Set.empty, Set.empty) should equal(Set(
+        aRel1B,
+        aRel2CD
+      ))
+
+      schema.schemaPatternsFor(Set("C"), Set.empty, Set.empty) should equal(Set(
+        CDRel1A
+      ))
+    }
+
+    it("works when only the target node label is known") {
+      schema.schemaPatternsFor(Set.empty, Set.empty, Set("A")) should equal(Set(
+        CDRel1A
+      ))
+
+      schema.schemaPatternsFor(Set.empty, Set.empty, Set("C")) should equal(Set(
+        aRel2CD,
+        bRel2CD
+      ))
+    }
+
+    it("works when only the rel type is known") {
+      schema.schemaPatternsFor(Set.empty, Set("REL1"), Set.empty) should equal(Set(
+        aRel1B,
+        CDRel1A,
+        emptyRel1Empty
+      ))
+
+      schema.schemaPatternsFor(Set.empty, Set("REL1", "REL2"), Set.empty) should equal(Set(
+        aRel1B,
+        aRel2CD,
+        bRel2CD,
+        CDRel1A,
+        emptyRel1Empty
+      ))
+    }
+
+    it("works when every thing is known") {
+      schema.schemaPatternsFor(Set("A"), Set("REL1"), Set("B")) should equal(Set(
+        aRel1B
+      ))
+
+      schema.schemaPatternsFor(Set("A"), Set("REL2"), Set("C")) should equal(Set(
+        aRel2CD
+      ))
+
+      schema.schemaPatternsFor(Set("A"), Set("REL1"), Set("C")) shouldBe empty
+    }
+
+    it("works for no existing labels/types") {
+      schema.schemaPatternsFor(Set("A", "B"), Set.empty, Set.empty) shouldBe empty
+      schema.schemaPatternsFor(Set.empty, Set.empty, Set("A", "B")) shouldBe empty
+      schema.schemaPatternsFor(Set.empty, Set("REL3"), Set.empty) shouldBe empty
+    }
   }
 
 }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/schema/CAPSSchema.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/schema/CAPSSchema.scala
@@ -140,4 +140,8 @@ case class CAPSSchema private[schema](schema: Schema) extends Schema {
   override def withOverwrittenRelationshipPropertyKeys(relType: String, propertyKeys: PropertyKeys): Schema = schema.withOverwrittenRelationshipPropertyKeys(relType, propertyKeys)
 
   override def toJson: String = schema.toJson
+
+  override def explicitSchemaPatterns: Set[SchemaPattern] = schema.explicitSchemaPatterns
+
+  override def schemaPatternsFor(knownSourceLabels: Set[String], knownRelTypes: Set[String], knownTargetLabels: Set[String]): Set[SchemaPattern] = schema.schemaPatternsFor(knownSourceLabels, knownRelTypes, knownTargetLabels)
 }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/schema/CAPSSchema.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/schema/CAPSSchema.scala
@@ -29,7 +29,7 @@ package org.opencypher.spark.schema
 import org.opencypher.okapi.api.schema.LabelPropertyMap.LabelPropertyMap
 import org.opencypher.okapi.api.schema.PropertyKeys.PropertyKeys
 import org.opencypher.okapi.api.schema.RelTypePropertyMap.RelTypePropertyMap
-import org.opencypher.okapi.api.schema.{LabelPropertyMap, RelTypePropertyMap, Schema}
+import org.opencypher.okapi.api.schema.{Schema, SchemaPattern}
 import org.opencypher.okapi.api.types.{CTRelationship, CypherType}
 import org.opencypher.okapi.impl.exception.{SchemaException, UnsupportedOperationException}
 import org.opencypher.okapi.impl.schema.{ImpliedLabels, LabelCombinations}
@@ -92,6 +92,10 @@ case class CAPSSchema private[schema](schema: Schema) extends Schema {
   override def labelPropertyMap: LabelPropertyMap = schema.labelPropertyMap
 
   override def relTypePropertyMap: RelTypePropertyMap = schema.relTypePropertyMap
+
+  override def schemaPatterns: Set[SchemaPattern] = schema.schemaPatterns
+
+  override def withSchemaPatterns(patterns: SchemaPattern*): Schema = schema.withSchemaPatterns(patterns: _*)
 
   override def impliedLabels: ImpliedLabels = schema.impliedLabels
 


### PR DESCRIPTION
Schema patterns are either computed (all possible combinations) or provided explicitly.
If any schema patterns are explicitly defined we assume those describe the schema in full. 

An alternative approach could be to make this distinction on a relationship type basis, i.e. for every rel type that occurs in an explicitly defined schema pattern, we make the above assumption and for any other rel types we assume all possible combinations.  