### PR TITLE
Remove cluster profile

### DIFF
--- a/okapi-neo4j-io/pom.xml
+++ b/okapi-neo4j-io/pom.xml
@@ -24,14 +24,6 @@
       <version>${project.parent.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.opencypher</groupId>
-      <artifactId>okapi-api</artifactId>
-      <version>${project.parent.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Neo4j -->
     <dependency>
       <groupId>org.neo4j.driver</groupId>

--- a/okapi-neo4j-procedures/pom.xml
+++ b/okapi-neo4j-procedures/pom.xml
@@ -43,4 +43,56 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${plugin.maven-shade.version}</version>
+        <executions>
+          <!-- run shade goal on package phase -->
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>${project.artifact.classifier}</shadedClassifierName>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <exclude>junit:junit</exclude>
+                  <exclude>jmock:*</exclude>
+                  <exclude>org.scala-lang:*</exclude>
+                  <exclude>org.scalatest:*</exclude>
+                  <exclude>org.scalacheck:*</exclude>
+                  <exclude>org.apache.maven:lib:tests</exclude>
+                  <exclude>commons-beanutils:*</exclude>
+                  <exclude>aopalliance:*</exclude>
+                  <exclude>javax.inject:*</exclude>
+                </excludes>
+              </artifactSet>
+              <filters>
+
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <!--Exclude Java 9 modules-->
+                    <exclude>**/module-info.class</exclude>
+                    <exclude>META-INF/versions/9/**/*</exclude>
+                  </excludes>
+                </filter>
+
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <project.scala.binary.version>2.11</project.scala.binary.version>
     <project.scala.version>${project.scala.binary.version}.12</project.scala.version>
     <project.rootdir>${project.basedir}</project.rootdir>
-    <project.artifact.classifier>standalone</project.artifact.classifier>
+    <project.artifact.classifier>cluster</project.artifact.classifier>
     <java9.exports></java9.exports>
 
     <!-- Used plugins -->
@@ -72,7 +72,7 @@
     <dep.neo4j.driver.version>1.6.1</dep.neo4j.driver.version>
     <dep.opencypher.front-end.version>9.0.7</dep.opencypher.front-end.version>
     <dep.spark.version>2.2.1</dep.spark.version>
-    <dep.spark.scope>compile</dep.spark.scope>
+    <dep.spark.scope>provided</dep.spark.scope>
     <dep.upickle.version>0.6.6</dep.upickle.version>
     <dep.log4j.core.version>2.11.0</dep.log4j.core.version>
     <dep.log4j.scala.api.version>11.0</dep.log4j.scala.api.version>
@@ -87,6 +87,24 @@
     <dep.scalacheck.version>1.13.5</dep.scalacheck.version>
     <dep.spark-measure.version>0.11</dep.spark-measure.version>
   </properties>
+
+  <modules>
+    <module>licensecheck-config</module>
+    <module>okapi-api</module>
+    <module>okapi-testing</module>
+    <module>okapi-neo4j-io</module>
+    <module>okapi-neo4j-io-testing</module>
+    <module>okapi-ir</module>
+    <module>okapi-neo4j-procedures</module>
+    <module>okapi-logical</module>
+    <module>okapi-relational</module>
+    <module>okapi-tck</module>
+    <module>okapi-trees</module>
+    <module>spark-cypher</module>
+    <module>spark-cypher-examples</module>
+    <module>spark-cypher-tck</module>
+    <module>spark-cypher-testing</module>
+  </modules>
 
   <build>
     <resources>
@@ -352,51 +370,27 @@
         </executions>
       </plugin>
 
+      <!-- License header checking -->
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+      </plugin>
+
     </plugins>
 
   </build>
 
   <profiles>
-
     <profile>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <id>testing</id>
-      <properties>
-        <dep.spark.scope>compile</dep.spark.scope>
-      </properties>
-
-      <!-- No license listing for this profile -->
-      <modules>
-        <module>okapi-api</module>
-        <module>okapi-testing</module>
-        <module>okapi-neo4j-io</module>
-        <module>okapi-neo4j-io-testing</module>
-        <module>okapi-ir</module>
-        <module>okapi-neo4j-procedures</module>
-        <module>okapi-logical</module>
-        <module>okapi-relational</module>
-        <module>okapi-tck</module>
-        <module>okapi-trees</module>
-        <module>spark-cypher</module>
-        <module>spark-cypher-examples</module>
-        <module>spark-cypher-tck</module>
-        <module>spark-cypher-testing</module>
-      </modules>
-    </profile>
-
-    <profile>
-      <id>check-licenses</id>
+      <!-- Disable plugin for parent module -->
+      <id>no-license-listing-for-parent-module</id>
       <activation>
         <activeByDefault>false</activeByDefault>
         <file>
           <exists>src/main/scala</exists>
         </file>
-        <property>
-          <name>cluster</name>
-        </property>
       </activation>
+
       <build>
         <plugins>
           <!-- License file checking-->
@@ -404,98 +398,9 @@
             <groupId>org.neo4j.build.plugins</groupId>
             <artifactId>licensing-maven-plugin</artifactId>
           </plugin>
-
-          <!-- License header checking -->
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-          </plugin>
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>cluster-package</id>
-      <properties>
-        <project.artifact.classifier>cluster</project.artifact.classifier>
-        <dep.spark.scope>provided</dep.spark.scope>
-      </properties>
-      <activation>
-        <property>
-          <name>cluster</name>
-        </property>
-      </activation>
-
-      <modules>
-        <module>licensecheck-config</module>
-        <module>okapi-api</module>
-        <module>okapi-testing</module>
-        <module>okapi-neo4j-io</module>
-        <module>okapi-neo4j-io-testing</module>
-        <module>okapi-ir</module>
-        <module>okapi-neo4j-procedures</module>
-        <module>okapi-logical</module>
-        <module>okapi-relational</module>
-        <module>okapi-tck</module>
-        <module>okapi-trees</module>
-        <module>spark-cypher</module>
-        <module>spark-cypher-testing</module>
-      </modules>
-
-      <build>
-        <plugins>
-          <!-- shade plugin -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>${plugin.maven-shade.version}</version>
-            <executions>
-              <!-- run shade goal on package phase -->
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <shadedArtifactAttached>true</shadedArtifactAttached>
-                  <shadedClassifierName>${project.artifact.classifier}</shadedClassifierName>
-                  <createDependencyReducedPom>true</createDependencyReducedPom>
-                  <artifactSet>
-                    <excludes>
-                      <exclude>junit:junit</exclude>
-                      <exclude>jmock:*</exclude>
-                      <exclude>org.scala-lang:*</exclude>
-                      <exclude>org.scalatest:*</exclude>
-                      <exclude>org.scalacheck:*</exclude>
-                      <exclude>org.apache.maven:lib:tests</exclude>
-                      <exclude>commons-beanutils:*</exclude>
-                      <exclude>aopalliance:*</exclude>
-                      <exclude>javax.inject:*</exclude>
-                    </excludes>
-                  </artifactSet>
-                  <filters>
-
-                    <filter>
-                      <artifact>*:*</artifact>
-                      <excludes>
-                        <exclude>META-INF/*.SF</exclude>
-                        <exclude>META-INF/*.DSA</exclude>
-                        <exclude>META-INF/*.RSA</exclude>
-                        <!--Exclude Java 9 modules-->
-                        <exclude>**/module-info.class</exclude>
-                        <exclude>META-INF/versions/9/**/*</exclude>
-                      </excludes>
-                    </filter>
-
-                  </filters>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
   </profiles>
 
   <dependencies>

--- a/spark-cypher-examples/pom.xml
+++ b/spark-cypher-examples/pom.xml
@@ -52,4 +52,20 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>licensing-maven-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <id>list-all-licenses</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/spark-cypher-testing/LICENSES.txt
+++ b/spark-cypher-testing/LICENSES.txt
@@ -4,8 +4,12 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  aopalliance version 1.0 repackaged as a module
   Apache Avro
+  Apache Avro IPC
+  Apache Avro Mapred API
   Apache Commons Codec
+  Apache Commons Crypto
   Apache Commons Lang
   Apache Commons Math
   Apache Commons Text
@@ -13,14 +17,22 @@ Apache Software License, Version 2.0
   Apache Directory LDAP API Utilities
   Apache Hadoop Annotations
   Apache Hadoop Auth
+  Apache Hadoop Client
   Apache Hadoop Common
   Apache Hadoop HDFS
   Apache Hadoop Mini-Cluster
   Apache HttpClient
   Apache HttpCore
+  Apache Ivy
   Apache Log4j
   Apache Log4j API
   Apache Log4j Core
+  Apache Parquet Column
+  Apache Parquet Common
+  Apache Parquet Encodings
+  Apache Parquet Format
+  Apache Parquet Hadoop
+  Apache Parquet Jackson
   Apache Shiro :: Cache
   Apache Shiro :: Configuration :: Core
   Apache Shiro :: Configuration :: OGDL
@@ -32,7 +44,10 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   ApacheDS I18n
   ApacheDS Protocol Kerberos Codec
+  Bean Validation API
   Caffeine cache
+  chill
+  chill-java
   Commons BeanUtils Core
   Commons CLI
   Commons Collections
@@ -44,6 +59,7 @@ Apache Software License, Version 2.0
   Commons Logging
   Commons Net
   commons-beanutils
+  Compress-LZF
   ConcurrentLinkedHashMap
   Curator Client
   Curator Framework
@@ -51,6 +67,7 @@ Apache Software License, Version 2.0
   Cypher for Apache Spark - CAPS
   Data Mapper for Jackson
   Digester
+  empty
   FindBugs-jsr305
   Google Guice - Core Library
   Google Guice - Extensions - Servlet
@@ -73,15 +90,34 @@ Apache Software License, Version 2.0
   hadoop-yarn-server-tests
   hadoop-yarn-server-web-proxy
   hazelcast-all
+  HK2 API module
+  HK2 Implementation Utilities
   htrace-core
   HttpClient
   Jackson
+  Jackson Integration for Metrics
+  Jackson-annotations
+  Jackson-core
+  jackson-databind
+  Jackson-module-paranamer
+  jackson-module-scala
   Java Servlet API
   java-xmlbuilder
   JavaBeans(TM) Activation Framework
   JavaMail API (compat)
+  Javassist
+  javax.annotation API
   javax.inject
+  javax.inject:1 as OSGi bundle
+  javax.ws.rs-api
   JAX-RS provider for JSON content type
+  jersey-container-servlet
+  jersey-container-servlet-core
+  jersey-core-client
+  jersey-core-common
+  jersey-core-server
+  jersey-media-jaxb
+  jersey-repackaged-guava
   JetS3t
   Jettison
   Jetty :: Http Utility
@@ -96,6 +132,10 @@ Apache Software License, Version 2.0
   Jetty Utilities
   jPowerShell
   jProcesses
+  json4s-ast
+  json4s-core
+  json4s-jackson
+  JVM Integration for Metrics
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -106,6 +146,7 @@ Apache Software License, Version 2.0
   MX4J
   Netty
   Netty/All-in-One
+  Objenesis
   Okapi - Neo4j IO
   Okapi - Neo4j IO test utils
   Okapi - Neo4j procedures
@@ -122,18 +163,33 @@ Apache Software License, Version 2.0
   openCypher Parser
   openCypher Rewriting
   openCypher Utils
+  oro
+  OSGi resource locator bundle - used by various API providers that rely on META-INF/services mechanism to locate providers.
   parboiled-core
   parboiled-scala
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  RoaringBitmap
   Scala 2.11 wrapper for Log4j API
   scalactic
   scalatest
+  ServiceLocator Default Implementation
   servlet-api
   snappy-java
+  Spark Project Catalyst
+  Spark Project Core
+  Spark Project Launcher
+  Spark Project Networking
+  Spark Project Shuffle Streaming Service
+  Spark Project Sketch
+  Spark Project SQL
+  Spark Project Tags
+  Spark Project Unsafe
   spark-measure
+  stream-lib
+  univocity-parsers
   WMI4Java
   Xerces2 Java Parser
   XML Commons External Components XML APIs
@@ -347,20 +403,27 @@ Apache Software License, Version 2.0
 
 ------------------------------------------------------------------------------
 BSD License
+  ANTLR 4 Runtime
   asm
   ASM Core
   asm-analysis
   asm-tree
   asm-util
+  Commons Compiler
+  Janino
   JLine
   JSch
+  Kryo Shaded
   leveldbjni-all
+  MinLog
   ParaNamer Core
   Protocol Buffer Java API
+  Py4J
   Scala Compiler
   Scala Library
   scala-parser-combinators
   scala-xml
+  Scalap
   xmlenc Library
 ------------------------------------------------------------------------------
 
@@ -431,8 +494,11 @@ MIT-license
   Cats kernel
   Cats macros
   core
+  JCL 1.1.1 implemented over SLF4J
+  JUL to SLF4J bridge
   machinist
   Mockito
+  pyrolite
   scallop
   SLF4J API Module
   SLF4J LOG4J-12 Binding

--- a/spark-cypher-testing/NOTICE.txt
+++ b/spark-cypher-testing/NOTICE.txt
@@ -28,8 +28,12 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  aopalliance version 1.0 repackaged as a module
   Apache Avro
+  Apache Avro IPC
+  Apache Avro Mapred API
   Apache Commons Codec
+  Apache Commons Crypto
   Apache Commons Lang
   Apache Commons Math
   Apache Commons Text
@@ -37,14 +41,22 @@ Apache Software License, Version 2.0
   Apache Directory LDAP API Utilities
   Apache Hadoop Annotations
   Apache Hadoop Auth
+  Apache Hadoop Client
   Apache Hadoop Common
   Apache Hadoop HDFS
   Apache Hadoop Mini-Cluster
   Apache HttpClient
   Apache HttpCore
+  Apache Ivy
   Apache Log4j
   Apache Log4j API
   Apache Log4j Core
+  Apache Parquet Column
+  Apache Parquet Common
+  Apache Parquet Encodings
+  Apache Parquet Format
+  Apache Parquet Hadoop
+  Apache Parquet Jackson
   Apache Shiro :: Cache
   Apache Shiro :: Configuration :: Core
   Apache Shiro :: Configuration :: OGDL
@@ -56,7 +68,10 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   ApacheDS I18n
   ApacheDS Protocol Kerberos Codec
+  Bean Validation API
   Caffeine cache
+  chill
+  chill-java
   Commons BeanUtils Core
   Commons CLI
   Commons Collections
@@ -68,6 +83,7 @@ Apache Software License, Version 2.0
   Commons Logging
   Commons Net
   commons-beanutils
+  Compress-LZF
   ConcurrentLinkedHashMap
   Curator Client
   Curator Framework
@@ -75,6 +91,7 @@ Apache Software License, Version 2.0
   Cypher for Apache Spark - CAPS
   Data Mapper for Jackson
   Digester
+  empty
   FindBugs-jsr305
   Google Guice - Core Library
   Google Guice - Extensions - Servlet
@@ -97,15 +114,34 @@ Apache Software License, Version 2.0
   hadoop-yarn-server-tests
   hadoop-yarn-server-web-proxy
   hazelcast-all
+  HK2 API module
+  HK2 Implementation Utilities
   htrace-core
   HttpClient
   Jackson
+  Jackson Integration for Metrics
+  Jackson-annotations
+  Jackson-core
+  jackson-databind
+  Jackson-module-paranamer
+  jackson-module-scala
   Java Servlet API
   java-xmlbuilder
   JavaBeans(TM) Activation Framework
   JavaMail API (compat)
+  Javassist
+  javax.annotation API
   javax.inject
+  javax.inject:1 as OSGi bundle
+  javax.ws.rs-api
   JAX-RS provider for JSON content type
+  jersey-container-servlet
+  jersey-container-servlet-core
+  jersey-core-client
+  jersey-core-common
+  jersey-core-server
+  jersey-media-jaxb
+  jersey-repackaged-guava
   JetS3t
   Jettison
   Jetty :: Http Utility
@@ -120,6 +156,10 @@ Apache Software License, Version 2.0
   Jetty Utilities
   jPowerShell
   jProcesses
+  json4s-ast
+  json4s-core
+  json4s-jackson
+  JVM Integration for Metrics
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -130,6 +170,7 @@ Apache Software License, Version 2.0
   MX4J
   Netty
   Netty/All-in-One
+  Objenesis
   Okapi - Neo4j IO
   Okapi - Neo4j IO test utils
   Okapi - Neo4j procedures
@@ -146,18 +187,33 @@ Apache Software License, Version 2.0
   openCypher Parser
   openCypher Rewriting
   openCypher Utils
+  oro
+  OSGi resource locator bundle - used by various API providers that rely on META-INF/services mechanism to locate providers.
   parboiled-core
   parboiled-scala
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  RoaringBitmap
   Scala 2.11 wrapper for Log4j API
   scalactic
   scalatest
+  ServiceLocator Default Implementation
   servlet-api
   snappy-java
+  Spark Project Catalyst
+  Spark Project Core
+  Spark Project Launcher
+  Spark Project Networking
+  Spark Project Shuffle Streaming Service
+  Spark Project Sketch
+  Spark Project SQL
+  Spark Project Tags
+  Spark Project Unsafe
   spark-measure
+  stream-lib
+  univocity-parsers
   WMI4Java
   Xerces2 Java Parser
   XML Commons External Components XML APIs
@@ -165,20 +221,27 @@ Apache Software License, Version 2.0
   zookeeper
 
 BSD License
+  ANTLR 4 Runtime
   asm
   ASM Core
   asm-analysis
   asm-tree
   asm-util
+  Commons Compiler
+  Janino
   JLine
   JSch
+  Kryo Shaded
   leveldbjni-all
+  MinLog
   ParaNamer Core
   Protocol Buffer Java API
+  Py4J
   Scala Compiler
   Scala Library
   scala-parser-combinators
   scala-xml
+  Scalap
   xmlenc Library
 
 Bouncy Castle License
@@ -191,8 +254,11 @@ MIT-license
   Cats kernel
   Cats macros
   core
+  JCL 1.1.1 implemented over SLF4J
+  JUL to SLF4J bridge
   machinist
   Mockito
+  pyrolite
   scallop
   SLF4J API Module
   SLF4J LOG4J-12 Binding

--- a/spark-cypher-testing/pom.xml
+++ b/spark-cypher-testing/pom.xml
@@ -49,7 +49,6 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${project.scala.binary.version}</artifactId>
       <version>${dep.spark.version}</version>
-      <scope>${dep.spark.scope}</scope>
       <exclusions>
         <!-- exclude netty-all as it interferes with neo4j-harness 3.4.1 -->
         <exclusion>
@@ -63,14 +62,12 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${project.scala.binary.version}</artifactId>
       <version>${dep.spark.version}</version>
-      <scope>${dep.spark.scope}</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${project.scala.binary.version}</artifactId>
       <version>${dep.spark.version}</version>
-      <scope>${dep.spark.scope}</scope>
     </dependency>
 
     <!-- Testing -->

--- a/spark-cypher/pom.xml
+++ b/spark-cypher/pom.xml
@@ -61,4 +61,57 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${plugin.maven-shade.version}</version>
+        <executions>
+          <!-- run shade goal on package phase -->
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>${project.artifact.classifier}</shadedClassifierName>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <exclude>junit:junit</exclude>
+                  <exclude>jmock:*</exclude>
+                  <exclude>org.scala-lang:*</exclude>
+                  <exclude>org.scalatest:*</exclude>
+                  <exclude>org.scalacheck:*</exclude>
+                  <exclude>org.apache.maven:lib:tests</exclude>
+                  <exclude>commons-beanutils:*</exclude>
+                  <exclude>aopalliance:*</exclude>
+                  <exclude>javax.inject:*</exclude>
+                </excludes>
+              </artifactSet>
+              <filters>
+
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <!--Exclude Java 9 modules-->
+                    <exclude>**/module-info.class</exclude>
+                    <exclude>META-INF/versions/9/**/*</exclude>
+                  </excludes>
+                </filter>
+
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Simplifies the pom by lifting module listing to the default scope and
removing the special `cluster` profile which had a different module list.
This will now build all the present modules by default.

License listing is disabled for the `spark-cypher-examples` module.
Shade plugin is moved to the modules where it is used.

Co-authored-by: Max Kießling <max.kiessling@neotechnology.com>