### PR TITLE
fixes #650: Feature request: Support `RegexMatch`

### DIFF
--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -414,6 +414,13 @@ final case class Equals(lhs: Expr, rhs: Expr)(val cypherType: CypherType = CTWil
   override def withCypherType(ct: CypherType): Equals = copy()(ct)
 }
 
+final case class RegexMatch(lhs: Expr, rhs: Expr) extends BinaryExpr {
+  override def op: String = "=~"
+  override type This = RegexMatch
+  override def cypherType: CypherType = if((lhs.cypherType join rhs.cypherType).isNullable) CTBoolean.nullable else CTBoolean
+  override def withCypherType(ct: CypherType): RegexMatch = this
+}
+
 final case class LessThan(lhs: Expr, rhs: Expr)(val cypherType: CypherType = CTWildcard) extends BinaryExpr {
 
   override type This = LessThan

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/ExpressionConverter.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/ExpressionConverter.scala
@@ -29,13 +29,14 @@ package org.opencypher.okapi.ir.impl
 import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.impl.exception.NotImplementedException
 import org.opencypher.okapi.ir.api.expr._
-import org.opencypher.okapi.ir.api.{CypherQuery, Label, PropertyKey, RelType}
+import org.opencypher.okapi.ir.api._
 import org.opencypher.okapi.ir.impl.FunctionUtils._
-import org.opencypher.v9_0.expressions.functions
+import org.opencypher.v9_0.expressions.{RegexMatch, functions}
 import org.opencypher.v9_0.util.Ref
 import org.opencypher.v9_0.{expressions => ast}
 
 import scala.language.implicitConversions
+import scala.util.parsing.combinator.token.StdTokens
 
 final class ExpressionConverter(implicit context: IRBuilderContext) {
 
@@ -144,6 +145,8 @@ final class ExpressionConverter(implicit context: IRBuilderContext) {
       MapExpression(convertedItems)(typings(e))
 
     case ast.Null() => NullLit(typings(e))
+
+    case RegexMatch(lhs, rhs) => expr.RegexMatch(convert(lhs), convert(rhs))
 
     case _ =>
       throw NotImplementedException(s"Not yet able to convert expression: $e")

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/CAPSRecordsAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/CAPSRecordsAcceptanceTest.scala
@@ -102,36 +102,6 @@ class CAPSRecordsAcceptanceTest extends CAPSTestSuite with CAPSNeo4jServerFixtur
     result.records shouldHaveSize 3 // andContain "Christopher Nolan"
   }
 
-  it("filter rels on property regular expression") {
-    // Given
-    val query = """MATCH (a:Actor)-[r:ACTED_IN]->() WHERE r.charactername =~ '(\\w+\\s*)*Du\\w+' RETURN r.charactername"""
-
-    // When
-    val result = graph.cypher(query)
-
-    // Then
-    val records = result.records.collect
-    records.toBag should equal(Bag(CypherMap("r.charactername" -> "Henri Ducard"),
-      CypherMap("r.charactername" -> "Albus Dumbledore")))
-  }
-
-  it("filter nodes on property regular expression") {
-    // Given
-    val query = """MATCH (p:Person) WHERE p.name =~ '\\w+ Redgrave' RETURN p.name"""
-
-    // When
-    val result = graph.cypher(query)
-
-    // Then
-    val records = result.records.collect
-    records.toBag should equal(Bag(CypherMap("p.name" -> "Michael Redgrave"),
-      CypherMap("p.name" -> "Vanessa Redgrave"),
-      CypherMap("p.name" -> "Corin Redgrave"),
-      CypherMap("p.name" -> "Jemma Redgrave"),
-      CypherMap("p.name" -> "Roy Redgrave")))
-
-  }
-
   it("expand and project, three properties") {
     // Given
     val query = "MATCH (a:Actor)-[:ACTED_IN]->(f:Film) RETURN a.name, f.title, a.birthyear"

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
@@ -82,11 +82,6 @@ object SparkSQLExprMapper {
       */
     def asSparkSQLExpr(implicit header: RecordHeader, df: DataFrame, parameters: CypherMap): Column = {
 
-      def rlike(lhs: Expr, name: String): Column = {
-        val regex: String = parameters(name).unwrap.toString
-        lhs.asSparkSQLExpr.rlike(regex)
-      }
-
       expr match {
 
         // context based lookups
@@ -163,8 +158,10 @@ object SparkSQLExprMapper {
         case Contains(lhs, rhs) =>
           lhs.asSparkSQLExpr.contains(rhs.asSparkSQLExpr)
 
-        case RegexMatch(prop, Param(name)) => rlike(prop, name)
-        case RegexMatch(Param(name), prop) => rlike(prop, name)
+        case RegexMatch(prop, Param(name)) => {
+          val regex: String = parameters(name).unwrap.toString
+          prop.asSparkSQLExpr.rlike(regex)
+        }
 
 
         // Arithmetics

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
@@ -82,6 +82,11 @@ object SparkSQLExprMapper {
       */
     def asSparkSQLExpr(implicit header: RecordHeader, df: DataFrame, parameters: CypherMap): Column = {
 
+      def rlike(lhs: Expr, name: String): Column = {
+        val regex: String = parameters(name).unwrap.toString
+        lhs.asSparkSQLExpr.rlike(regex)
+      }
+
       expr match {
 
         // context based lookups
@@ -157,6 +162,10 @@ object SparkSQLExprMapper {
           lhs.asSparkSQLExpr.endsWith(rhs.asSparkSQLExpr)
         case Contains(lhs, rhs) =>
           lhs.asSparkSQLExpr.contains(rhs.asSparkSQLExpr)
+
+        case RegexMatch(prop, Param(name)) => rlike(prop, name)
+        case RegexMatch(Param(name), prop) => rlike(prop, name)
+
 
         // Arithmetics
         case Add(lhs, rhs) =>


### PR DESCRIPTION
Hi guys,
I implemented this feature request.

In `CAPSRecordsAcceptanceTest` you'll find two test:

```scala
  it("filter rels on property regular expression") {
    // Given
    val query = """MATCH (a:Actor)-[r:ACTED_IN]->() WHERE r.charactername =~ '(\\w+\\s*)*Du\\w+' RETURN r.charactername"""

    // When
    val result = graph.cypher(query)

    // Then
    val records = result.records.collect
    records.toBag should equal(Bag(CypherMap("r.charactername" -> "Henri Ducard"),
      CypherMap("r.charactername" -> "Albus Dumbledore")))
  }

  it("filter nodes on property regular expression") {
    // Given
    val query = """MATCH (p:Person) WHERE p.name =~ '\\w+ Redgrave' RETURN p.name"""

    // When
    val result = graph.cypher(query)

    // Then
    val records = result.records.collect
    records.toBag should equal(Bag(CypherMap("p.name" -> "Michael Redgrave"),
      CypherMap("p.name" -> "Vanessa Redgrave"),
      CypherMap("p.name" -> "Corin Redgrave"),
      CypherMap("p.name" -> "Jemma Redgrave"),
      CypherMap("p.name" -> "Roy Redgrave")))

  }
```

Under the hood it uses the Spark's `rlike` function:

```scala
      def rlike(lhs: Expr, name: String): Column = {
        val regex: String = parameters(name).unwrap.toString
        lhs.asSparkSQLExpr.rlike(regex)
      }
```

Let me know what do you think about it.
Thanks

Signed-off-by: Andrea Santurbano santand@gmail.com