### PR TITLE
Migrate from scalatest-maven-plugin to surefire and JUnit4

### DIFF
--- a/okapi-api/pom.xml
+++ b/okapi-api/pom.xml
@@ -56,6 +56,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${dep.junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/okapi-api/src/test/scala/org/opencypher/okapi/ApiBaseTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/ApiBaseTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016-2018 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.okapi
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+abstract class BaseTest extends FunSpec with MockitoSugar with Matchers

--- a/okapi-api/src/test/scala/org/opencypher/okapi/ApiBaseTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/ApiBaseTest.scala
@@ -32,4 +32,4 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
 @RunWith(classOf[JUnitRunner])
-abstract class BaseTest extends FunSpec with MockitoSugar with Matchers
+abstract class ApiBaseTest extends FunSpec with MockitoSugar with Matchers

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/graph/CypherSessionTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/graph/CypherSessionTest.scala
@@ -26,16 +26,15 @@
  */
 package org.opencypher.okapi.api.graph
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.io.PropertyGraphDataSource
 import org.opencypher.okapi.api.table.CypherRecords
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
 import org.opencypher.okapi.impl.graph.CypherCatalog
 import org.opencypher.okapi.impl.io.SessionGraphDataSource
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
 
-class CypherSessionTest extends FunSpec with MockitoSugar with Matchers {
+class CypherSessionTest extends ApiBaseTest {
 
   it("avoid de-registering the session data source") {
     an[org.opencypher.okapi.impl.exception.UnsupportedOperationException] should be thrownBy

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/graph/QualifiedGraphNameTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/graph/QualifiedGraphNameTest.scala
@@ -26,10 +26,10 @@
  */
 package org.opencypher.okapi.api.graph
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.impl.io.SessionGraphDataSource.{Namespace => SessionNamespace}
-import org.scalatest.{FunSpec, Matchers}
 
-class QualifiedGraphNameTest extends FunSpec with Matchers {
+class QualifiedGraphNameTest extends ApiBaseTest {
 
   it("apply with string representation containing single namespace and single graph name") {
     val string = "testNamespace.testGraphName"

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/io/conversion/EntityMappingTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/io/conversion/EntityMappingTest.scala
@@ -26,10 +26,10 @@
  */
 package org.opencypher.okapi.api.io.conversion
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
-import org.scalatest.{FunSpec, Matchers}
 
-class EntityMappingTest extends FunSpec with Matchers {
+class EntityMappingTest extends ApiBaseTest {
 
   it("Construct node mapping") {
     val given = NodeMapping.on("id")

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/LabelCombinationsTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/LabelCombinationsTest.scala
@@ -26,10 +26,10 @@
  */
 package org.opencypher.okapi.api.schema
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.impl.schema.LabelCombinations
-import org.scalatest.{FunSpec, Matchers}
 
-class LabelCombinationsTest extends FunSpec with Matchers {
+class LabelCombinationsTest extends ApiBaseTest {
 
   it("combinationsFor") {
     val in = LabelCombinations(Set(

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/LabelPropertyMapTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/LabelPropertyMapTest.scala
@@ -28,12 +28,13 @@ package org.opencypher.okapi.api.schema
 
 import cats.instances.all._
 import cats.syntax.semigroup._
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.schema.LabelPropertyMap._
 import org.opencypher.okapi.api.types.CypherType.joinMonoid
 import org.opencypher.okapi.api.types.{CTAny, CTBoolean, CTInteger, CTString}
 import org.scalatest.{FunSpec, Matchers}
 
-class LabelPropertyMapTest extends FunSpec with Matchers {
+class LabelPropertyMapTest extends ApiBaseTest {
 
   it("|+|") {
     val map1 = LabelPropertyMap.empty

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/RelTypePropertyMapTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/RelTypePropertyMapTest.scala
@@ -28,12 +28,13 @@ package org.opencypher.okapi.api.schema
 
 import cats.instances.all._
 import cats.syntax.semigroup._
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.schema.RelTypePropertyMap._
 import org.opencypher.okapi.api.types.CypherType.joinMonoid
 import org.opencypher.okapi.api.types.{CTAny, CTBoolean, CTInteger, CTString}
 import org.scalatest.{FunSpec, Matchers}
 
-class RelTypePropertyMapTest extends FunSpec with Matchers {
+class RelTypePropertyMapTest extends ApiBaseTest {
 
   it("|+|") {
     val map1 = RelTypePropertyMap.empty

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/SchemaTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/schema/SchemaTest.scala
@@ -26,13 +26,14 @@
  */
 package org.opencypher.okapi.api.schema
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.schema.PropertyKeys.PropertyKeys
 import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.impl.exception.SchemaException
 import org.opencypher.okapi.impl.util.Version
 import org.scalatest.{FunSpec, Matchers}
 
-class SchemaTest extends FunSpec with Matchers {
+class SchemaTest extends ApiBaseTest {
 
   it("lists of void and others") {
     val s1 = Schema.empty.withNodePropertyKeys("A")("v" -> CTList(CTVoid))

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/types/CypherTypesTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/types/CypherTypesTest.scala
@@ -26,12 +26,13 @@
  */
 package org.opencypher.okapi.api.types
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.graph.QualifiedGraphName
 import org.scalatest.{FunSpec, Matchers}
 
 import scala.language.postfixOps
 
-class CypherTypesTest extends FunSpec with Matchers {
+class CypherTypesTest extends ApiBaseTest {
 
   val materialTypes: Seq[MaterialCypherType] = Seq(
     CTAny,

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/types/TernaryTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/types/TernaryTest.scala
@@ -26,9 +26,9 @@
  */
 package org.opencypher.okapi.api.types
 
-import org.scalatest.{FunSpec, Matchers}
+import org.opencypher.okapi.ApiBaseTest
 
-class TernaryTest extends FunSpec with Matchers {
+class TernaryTest extends ApiBaseTest {
 
   it("Ternary.toString") {
     True.toString shouldBe "definitely true"

--- a/okapi-api/src/test/scala/org/opencypher/okapi/api/value/CypherValueTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/api/value/CypherValueTest.scala
@@ -26,10 +26,10 @@
  */
 package org.opencypher.okapi.api.value
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.value.CypherValue.{CypherBoolean, CypherFloat, CypherInteger, CypherList, CypherMap, CypherNode, CypherRelationship, CypherString}
-import org.scalatest.{FunSpec, Matchers}
 
-class CypherValueTest extends FunSpec with Matchers {
+class CypherValueTest extends ApiBaseTest {
   describe("#toCypherString") {
     it("converts literals") {
       val mapping = Map(

--- a/okapi-api/src/test/scala/org/opencypher/okapi/impl/configuration/ConfigCachingTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/impl/configuration/ConfigCachingTest.scala
@@ -26,9 +26,9 @@
  */
 package org.opencypher.okapi.impl.configuration
 
-import org.scalatest.{FunSpec, FunSuite, Matchers}
+import org.opencypher.okapi.ApiBaseTest
 
-class ConfigCachingTest extends FunSpec with Matchers {
+class ConfigCachingTest extends ApiBaseTest {
 
   object TestConfigWithCaching extends ConfigFlag("test") with ConfigCaching[Boolean]
 

--- a/okapi-api/src/test/scala/org/opencypher/okapi/impl/graph/CypherCatalogTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/impl/graph/CypherCatalogTest.scala
@@ -26,14 +26,13 @@
  */
 package org.opencypher.okapi.impl.graph
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.graph._
 import org.opencypher.okapi.api.io.PropertyGraphDataSource
 import org.opencypher.okapi.impl.exception.{GraphNotFoundException, IllegalArgumentException}
 import org.opencypher.okapi.impl.io.SessionGraphDataSource
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
 
-class CypherCatalogTest extends FunSpec with MockitoSugar with Matchers  {
+class CypherCatalogTest extends ApiBaseTest  {
   it("avoids retrieving a non-registered data source") {
     an[IllegalArgumentException] should be thrownBy new CypherCatalog().source(Namespace("foo"))
   }

--- a/okapi-api/src/test/scala/org/opencypher/okapi/impl/io/SessionGraphDataSourceTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/impl/io/SessionGraphDataSourceTest.scala
@@ -27,13 +27,12 @@
 package org.opencypher.okapi.impl.io
 
 import org.mockito.Mockito._
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.graph.{GraphName, PropertyGraph}
 import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.impl.exception.GraphNotFoundException
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.mockito.MockitoSugar
 
-class SessionGraphDataSourceTest extends FunSpec with Matchers with MockitoSugar {
+class SessionGraphDataSourceTest extends ApiBaseTest {
 
   it("hasGraph should return true for existing graph") {
     val source = new SessionGraphDataSource

--- a/okapi-api/src/test/scala/org/opencypher/okapi/impl/util/TablePrinterTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/impl/util/TablePrinterTest.scala
@@ -26,12 +26,12 @@
  */
 package org.opencypher.okapi.impl.util
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.api.value.CypherValue
 import org.opencypher.okapi.api.value.CypherValue.{CypherMap, CypherNode, CypherRelationship, CypherValue}
 import org.opencypher.okapi.impl.util.TablePrinter.toTable
-import org.scalatest.{FunSpec, Matchers}
 
-class TablePrinterTest extends FunSpec with Matchers {
+class TablePrinterTest extends ApiBaseTest {
 
   it("prints empty header and data") {
     val header = Seq.empty

--- a/okapi-api/src/test/scala/org/opencypher/okapi/impl/util/VersionTest.scala
+++ b/okapi-api/src/test/scala/org/opencypher/okapi/impl/util/VersionTest.scala
@@ -26,10 +26,10 @@
  */
 package org.opencypher.okapi.impl.util
 
+import org.opencypher.okapi.ApiBaseTest
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
-import org.scalatest.{FunSpec, Matchers}
 
-class VersionTest extends FunSpec with Matchers {
+class VersionTest extends ApiBaseTest {
   describe("parsing") {
     it("parses two valued version numbers") {
       Version("1.0") should equal(Version(1,0))

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/IRFieldTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/IRFieldTest.scala
@@ -27,32 +27,33 @@
 package org.opencypher.okapi.ir.api
 
 import org.opencypher.okapi.api.types.{CTNode, CTRelationship}
-import org.scalatest.{FunSuite, Matchers}
+import org.opencypher.okapi.testing.BaseTestSuite
 
-class IRFieldTest extends FunSuite with Matchers {
+class IRFieldTest extends BaseTestSuite {
 
-  test("IRField ignores cypher type in equality") {
-    val a = IRField("a")(CTNode)
-    val b = IRField("a")(CTRelationship)
-    a should equal(b)
+  describe("equality") {
+    it("ignores cypher type in equality") {
+      val a = IRField("a")(CTNode)
+      val b = IRField("a")(CTRelationship)
+      a should equal(b)
+    }
+
+    it("has same hash code for different cypher types") {
+      val n = IRField("a")(CTNode("a"))
+      val r = IRField("a")(CTRelationship("b"))
+      n.hashCode should equal(r.hashCode)
+    }
+
+    it("can be unequal") {
+      val a = IRField("a")()
+      val b = IRField("b")()
+      a should not equal b
+    }
+
+    it("has different hash codes") {
+      val a = IRField("a")()
+      val b = IRField("b")()
+      a.hashCode should not equal b.hashCode
+    }
   }
-
-  test("same IRFields with different cypher types have the same hash code") {
-    val n = IRField("a")(CTNode("a"))
-    val r = IRField("a")(CTRelationship("b"))
-    n.hashCode should equal(r.hashCode)
-  }
-
-  test("different IRFields are not equal") {
-    val a = IRField("a")()
-    val b = IRField("b")()
-    a should not equal b
-  }
-
-  test("different IRFields have different hash codes") {
-    val a = IRField("a")()
-    val b = IRField("b")()
-    a.hashCode should not equal b.hashCode
-  }
-
 }

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
@@ -27,9 +27,9 @@
 package org.opencypher.okapi.ir.api.expr
 
 import org.opencypher.okapi.api.types._
-import org.scalatest.{FunSuite, Matchers}
+import org.opencypher.okapi.testing.BaseTestSuite
 
-class ExprTest extends FunSuite with Matchers {
+class ExprTest extends BaseTestSuite {
 
   test("expressions ignore cypher type in equality") {
     val n = Var("a")(CTInteger)

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
@@ -685,7 +685,7 @@ class IrBuilderTest extends IrTestSuite {
         """
           |MATCH (:FOO)-[r:REL]->()
           |CONSTRUCT
-          |  CLONE r
+          |  CLONE r AS r
           |  CREATE (:A)-[r]->()
           |RETURN GRAPH
         """.stripMargin

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
@@ -653,7 +653,7 @@ class IrBuilderTest extends IrTestSuite {
         """
           |MATCH ()-[r]->()
           |CONSTRUCT
-          | CLONE r
+          | CLONE r AS r
           |RETURN GRAPH
         """.stripMargin
 
@@ -665,7 +665,7 @@ class IrBuilderTest extends IrTestSuite {
         """
           |MATCH (:FOO)-[r:REL]->()
           |CONSTRUCT
-          | CLONE r as newR
+          | CLONE r AS newR
           | CREATE (:A)-[newR]->()
           |RETURN GRAPH
         """.stripMargin

--- a/okapi-neo4j-procedures/src/test/scala/org/opencypher/okapi/procedures/OkapiTest.scala
+++ b/okapi-neo4j-procedures/src/test/scala/org/opencypher/okapi/procedures/OkapiTest.scala
@@ -26,16 +26,19 @@
  */
 package org.opencypher.okapi.procedures
 
+import org.junit.runner.RunWith
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.kernel.impl.proc.Procedures
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.TestGraphDatabaseFactory
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+@RunWith(classOf[JUnitRunner])
 class OkapiTest extends FunSuite with BeforeAndAfter with Matchers {
   private var db: GraphDatabaseService = _
 

--- a/okapi-relational/src/test/scala/org/opencypher/okapi/relational/api/schema/RelationalSchemaTest.scala
+++ b/okapi-relational/src/test/scala/org/opencypher/okapi/relational/api/schema/RelationalSchemaTest.scala
@@ -32,9 +32,9 @@ import org.opencypher.okapi.ir.api.expr._
 import org.opencypher.okapi.ir.api.{Label, PropertyKey, RelType}
 import org.opencypher.okapi.relational.api.schema.RelationalSchema._
 import org.opencypher.okapi.relational.impl.table.RecordHeader
-import org.scalatest.{FunSpec, Matchers}
+import org.opencypher.okapi.testing.BaseTestSuite
 
-class RelationalSchemaTest extends FunSpec with Matchers {
+class RelationalSchemaTest extends BaseTestSuite {
 
   it("creates a header for given node") {
     val schema = Schema.empty

--- a/okapi-testing/pom.xml
+++ b/okapi-testing/pom.xml
@@ -19,7 +19,6 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.opencypher</groupId>
       <artifactId>okapi-api</artifactId>
@@ -42,6 +41,12 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-jdk15on</artifactId>
       <version>${dep.bouncycastle.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${dep.junit.version}</version>
     </dependency>
 
     <dependency>

--- a/okapi-testing/src/main/scala/org/opencypher/okapi/testing/BaseTestSuite.scala
+++ b/okapi-testing/src/main/scala/org/opencypher/okapi/testing/BaseTestSuite.scala
@@ -26,17 +26,20 @@
  */
 package org.opencypher.okapi.testing
 
+import org.junit.runner.RunWith
 import org.mockito.Mockito.when
 import org.opencypher.okapi.api.graph.{GraphName, Namespace, QualifiedGraphName}
 import org.opencypher.okapi.api.io.PropertyGraphDataSource
 import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.impl.graph.QGNGenerator
 import org.scalactic.source
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers, Tag}
 
 import scala.util.Random
 
+@RunWith(classOf[JUnitRunner])
 abstract class BaseTestSuite extends FunSpec with Matchers with MockitoSugar {
 
   /* Shared test objects */

--- a/okapi-testing/src/test/scala/org/opencypher/okapi/testing/BagTest.scala
+++ b/okapi-testing/src/test/scala/org/opencypher/okapi/testing/BagTest.scala
@@ -29,7 +29,7 @@ package org.opencypher.okapi.testing
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.scalatest.{FunSpec, Matchers}
 
-class BagTest extends FunSpec with Matchers {
+class BagTest extends BaseTestSuite {
 
   it("considers maps with the same content equal") {
     Bag(

--- a/okapi-trees/pom.xml
+++ b/okapi-trees/pom.xml
@@ -26,6 +26,13 @@
       <version>${dep.cats.version}</version>
     </dependency>
 
+    <!-- Testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${dep.junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/okapi-trees/src/test/scala/org/opencypher/okapi/trees/TreeNodeTest.scala
+++ b/okapi-trees/src/test/scala/org/opencypher/okapi/trees/TreeNodeTest.scala
@@ -27,8 +27,11 @@
 package org.opencypher.okapi.trees
 
 import cats.data.NonEmptyList
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FunSpec, Matchers}
 
+@RunWith(classOf[JUnitRunner])
 class TreeNodeTest extends FunSpec with Matchers {
 
   val calculation = Add(Number(5), Add(Number(4), Number(3)))

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <plugin.maven-resources.version>2.7</plugin.maven-resources.version>
     <plugin.maven-scala.version>3.2.1</plugin.maven-scala.version>
     <plugin.maven-scalastyle.version>0.8.0</plugin.maven-scalastyle.version>
-    <plugin.maven-scalatest.version>2.0.0</plugin.maven-scalatest.version>
     <plugin.maven-shade.version>3.1.1</plugin.maven-shade.version>
     <plugin.maven-surefire.version>2.20.1</plugin.maven-surefire.version>
 
@@ -338,38 +337,11 @@
         </configuration>
       </plugin>
 
-      <!-- disable surefire -->
+      <!-- We run tests with surefire -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${plugin.maven-surefire.version}</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-      </plugin>
-
-      <!-- enable scalatest -->
-      <plugin>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest-maven-plugin</artifactId>
-        <version>${plugin.maven-scalatest.version}</version>
-        <configuration>
-          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-          <junitxml>.</junitxml>
-          <forkMode>never</forkMode>
-          <filereports>WDF TestSuite.txt</filereports>
-          <tagsToExclude>CAPSPatternGraphFactory</tagsToExclude>
-          <!-- Enable full exception stack traces -->
-          <stdout>F</stdout>
-        </configuration>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <!-- License header checking -->

--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,8 @@
 
     <!-- Test scope dependencies -->
     <dep.bouncycastle.version>1.59</dep.bouncycastle.version>
-    <dep.junit.version>5.0.2</dep.junit.version>
+    <dep.junit.version>4.12</dep.junit.version>
     <dep.junit.platform.version>1.0.2</dep.junit.platform.version>
-    <dep.junit.vintage.version>4.12.2</dep.junit.vintage.version>
     <dep.mockito.version>1.10.19</dep.mockito.version>
     <dep.scalatest.version>3.0.5</dep.scalatest.version>
     <dep.scalacheck.version>1.13.5</dep.scalacheck.version>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>${plugin.maven-scala.version}</version>
         <configuration>
-          <recompileMode>incremental</recompileMode>
+          <!--<recompileMode>incremental</recompileMode>-->
           <scalaVersion>${project.scala.version}</scalaVersion>
           <scalaCompatVersion>${project.scala.binary.version}</scalaCompatVersion>
           <encoding>${project.build.encoding}</encoding>

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/RecommendationExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/RecommendationExample.scala
@@ -92,7 +92,6 @@ object RecommendationExample extends ConsoleApp {
        |MATCH (c:Customer)
        |WHERE c.name = p.name
        |CONSTRUCT ON purchases.products, allFriends
-       |  CLONE c, p
        |  CREATE (c)-[:IS]->(p)
        |RETURN GRAPH
       """.stripMargin).graph

--- a/spark-cypher-examples/src/test/scala/org/opencypher/spark/examples/ExampleTest.scala
+++ b/spark-cypher-examples/src/test/scala/org/opencypher/spark/examples/ExampleTest.scala
@@ -29,10 +29,13 @@ package org.opencypher.spark.examples
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.net.URI
 
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 import scala.io.Source
 
+@RunWith(classOf[JUnitRunner])
 abstract class ExampleTest extends FunSpec with Matchers with BeforeAndAfterAll {
 
   private val oldStdOut = System.out

--- a/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/impl/convert/SparkConversionsTest.scala
+++ b/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/impl/convert/SparkConversionsTest.scala
@@ -28,10 +28,10 @@ package org.opencypher.spark.testing.impl.convert
 
 import org.apache.spark.sql.types._
 import org.opencypher.okapi.api.types._
-import org.scalatest.{FunSpec, Matchers}
+import org.opencypher.okapi.testing.BaseTestSuite
 import org.opencypher.spark.impl.convert.SparkConversions._
 
-class SparkConversionsTest extends FunSpec with Matchers {
+class SparkConversionsTest extends BaseTestSuite {
 
   it("should produce the correct StructField for non-nested types") {
     CTInteger.toStructField("foo") should equal(StructField("foo", LongType, nullable = false))

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/TagsTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/TagsTest.scala
@@ -28,9 +28,9 @@ package org.opencypher.spark.api
 
 import org.opencypher.okapi.impl.exception.IllegalStateException
 import org.opencypher.okapi.relational.api.tagging.Tags._
-import org.scalatest.{FunSpec, Matchers}
+import org.opencypher.okapi.testing.BaseTestSuite
 
-class TagsTest extends FunSpec with Matchers {
+class TagsTest extends BaseTestSuite {
 
   it("picks a free tag") {
     pickFreeTag(Set.empty) shouldBe 0

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/util/StringEncodingUtilitiesTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/util/StringEncodingUtilitiesTest.scala
@@ -27,10 +27,10 @@
 package org.opencypher.spark.api.io.util
 
 import org.opencypher.okapi.impl.util.StringEncodingUtilities._
+import org.opencypher.okapi.testing.BaseTestSuite
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{FunSpec, Matchers}
 
-class StringEncodingUtilitiesTest extends FunSpec with GeneratorDrivenPropertyChecks with Matchers {
+class StringEncodingUtilitiesTest extends BaseTestSuite with GeneratorDrivenPropertyChecks {
 
   it("encodes arbitrary strings with only letters, digits, underscores, hashes, and 'at' symbols") {
     forAll { s: String =>

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/SingleTableGraphTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/SingleTableGraphTest.scala
@@ -54,7 +54,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
     val person = inputGraph.cypher(
       """MATCH (a :Swedish)
         |CONSTRUCT
-        |  CLONE a
+        |  CLONE a AS a
         |RETURN GRAPH
       """.stripMargin)
 
@@ -70,7 +70,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
     val person = inputGraph.cypher(
       """MATCH (a:Person:Swedish)-[r]->(b)
         |CONSTRUCT
-        |  CLONE a, b, r
+        |  CLONE a AS a, b AS b, r AS r
         |  CREATE (a)-[r]->(b)
         |RETURN GRAPH
       """.stripMargin)
@@ -90,7 +90,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
     val person = inputGraph.cypher(
       """MATCH (a:Person:Swedish)-[r]->(b)
         |CONSTRUCT
-        |  CLONE a, b
+        |  CLONE a AS a, b AS b
         |  CREATE (a)-[foo:SWEDISH_KNOWS]->(b)
         |RETURN GRAPH
       """.stripMargin)
@@ -137,7 +137,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
     val person = inputGraph.cypher(
       """MATCH (a:Person:Swedish)-[r]->(b)
         |CONSTRUCT
-        |  CLONE a, r, b
+        |  CLONE a AS a, r AS r, b AS b
         |  CREATE (a)-[r]->(b)-[:KNOWS_A]->()
         |RETURN GRAPH
       """.stripMargin)
@@ -210,7 +210,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
     val person = inputGraph.cypher(
       """MATCH (a:Person:Swedish)-[r]->(b)
         |CONSTRUCT
-        |  CLONE a, r, b
+        |  CLONE a AS a, r AS r, b AS b
         |  CREATE (a)-[r]->(b)-[bar:KNOWS_A]->(baz:Swede)
         |RETURN GRAPH
       """.stripMargin)
@@ -404,7 +404,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
         |MATCH (i:Interest)<-[h:HAS_INTEREST]-(a:Person)-[k:KNOWS]->(b:Person)
         |WITH DISTINCT a, b
         |CONSTRUCT
-        |  CLONE a, b
+        |  CLONE a AS a, b AS b
         |  CREATE (a)-[f:FOO]->(b)
         |RETURN GRAPH
       """.stripMargin)
@@ -450,7 +450,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
       """
         |MATCH (i:Interest)<-[h:HAS_INTEREST]-(a:Person)-[k:KNOWS]->(b:Person)
         |CONSTRUCT
-        |  CLONE a, b
+        |  CLONE a AS a, b AS b
         |  CREATE (a)-[:FOO]->(b)
         |RETURN GRAPH
       """.stripMargin)
@@ -474,7 +474,7 @@ class SingleTableGraphTest extends CAPSGraphTest with RecordsVerificationFixture
       """
         |MATCH (i:Interest)<-[h:HAS_INTEREST]-(a:Person)-[k:KNOWS]->(b:Person)
         |CONSTRUCT
-        |  CLONE a
+        |  CLONE a AS a
         |  CREATE (a)
         |RETURN GRAPH
       """.stripMargin)

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/CatalogDDLBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/CatalogDDLBehaviour.scala
@@ -383,8 +383,8 @@ class CatalogDDLBehaviour extends CAPSTestSuite with DefaultGraphInit with Befor
           | FROM GRAPH $g2
           | MATCH (m)
           | CONSTRUCT
-          |   CLONE n
-          |   CLONE m
+          |   CLONE n AS n
+          |   CLONE m AS m
           | RETURN GRAPH
           |}
         """.stripMargin)
@@ -421,7 +421,7 @@ class CatalogDDLBehaviour extends CAPSTestSuite with DefaultGraphInit with Befor
           | FROM GRAPH $g2
           | MATCH (m)
           | CONSTRUCT
-          |   CLONE n
+          |   CLONE n AS n
           |   CREATE (COPY OF m)
           | RETURN GRAPH
           |}

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/MultipleGraphBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/MultipleGraphBehaviour.scala
@@ -94,25 +94,12 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
   }
 
   //TODO: This test has no useful expectation
-  it("CLONEs without an alias") {
-    val query =
-      """
-        |MATCH (n)
-        |CONSTRUCT
-        |  CLONE n
-        |RETURN GRAPH""".stripMargin
-
-    val result = testGraph1.cypher(query)
-    result.getRecords should be(None)
-  }
-
-  //TODO: This test has no useful expectation
   it("CLONEs with an alias") {
     val query =
       """
         |MATCH (n)
         |CONSTRUCT
-        |  CLONE n as m
+        |  CLONE n AS m
         |RETURN GRAPH""".stripMargin
 
     val result = testGraph1.cypher(query)
@@ -338,7 +325,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
     val query =
       """|MATCH (m:Person)
          |CONSTRUCT
-         |  CLONE m
+         |  CLONE m AS m
          |RETURN GRAPH""".stripMargin
 
     val result = testGraph1.cypher(query)
@@ -504,7 +491,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
         |MATCH (n),(m)
         |WHERE n.name = 'Mats' AND m.name = 'Phil'
         |CONSTRUCT
-        | CLONE n, m
+        | CLONE n AS n, m AS m
         | CREATE (n)-[r:KNOWS]->(m)
         |RETURN GRAPH
       """.stripMargin)
@@ -542,7 +529,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
         |MATCH (n)-[:KNOWS]->(m)
         |WITH DISTINCT n, m
         |CONSTRUCT
-        | CLONE n, m
+        | CLONE n AS n, m AS m
         | CREATE (n)-[r:KNOWS]->(m)
         |RETURN GRAPH
       """.stripMargin)
@@ -588,7 +575,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
       """
         |MATCH (n)-[:KNOWS]->(m)
         |CONSTRUCT
-        | CLONE n, m
+        | CLONE n AS n, m AS m
         | CREATE (n)-[r:KNOWS]->(m)
         |RETURN GRAPH
       """.stripMargin)
@@ -681,7 +668,6 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
          |FROM GRAPH two
          |MATCH (p: Person)
          |CONSTRUCT ON one, two
-         |  CLONE m, p
          |  CREATE (m)-[:KNOWS]->(p)
          |RETURN GRAPH""".stripMargin
 
@@ -743,11 +729,11 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
         |FROM GRAPH g1
         |MATCH (a)
         |CONSTRUCT // generated qgn
-        |  CLONE a
+        |  CLONE a AS a
         |MATCH (b)
         |CONSTRUCT
         |  ON g1
-        |  CLONE b
+        |  CLONE b AS b
         |RETURN GRAPH
       """.stripMargin
 
@@ -774,7 +760,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
         |MATCH (b:Person)
         |CONSTRUCT
         |  ON g2
-        |  CLONE a, b
+        |  CLONE a AS a, b AS b
         |RETURN GRAPH
       """.stripMargin
 
@@ -795,7 +781,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
       """|FROM GRAPH testGraphRels1
          |MATCH (p1 :Person)-[r1]->(p2 :Person)
          |CONSTRUCT ON testGraphRels2
-         |  CLONE p1, r1, p2
+         |  CLONE p1 AS p1, r1 AS r1, p2 AS p2
          |  CREATE (p1)-[ r1]->( p2)
          |RETURN GRAPH""".stripMargin
 
@@ -834,7 +820,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
          |FROM GRAPH testGraphRels2
          |MATCH (p3 :Person)-[r2]->(p4 :Person)
          |CONSTRUCT
-         |  CLONE p1, p2, p3, p4, r1, r2
+         |  CLONE p1 AS p1, p2 AS p2, p3 AS p3, p4 AS p4, r1 AS r1, r2 AS r2
          |  CREATE (p1)-[r1]->(p2)
          |  CREATE (p3)-[r2]->(p4)
          |RETURN GRAPH""".stripMargin
@@ -861,7 +847,7 @@ class MultipleGraphBehaviour extends CAPSTestSuite with ScanGraphInit {
          |  CREATE (a:A)-[r:FOO]->(b:B)
          |MATCH (a)-->(b)
          |CONSTRUCT
-         |  CLONE a, b
+         |  CLONE a AS a, b AS b
          |  CREATE (a)-[:KNOWS]->(b)
          |RETURN GRAPH""".stripMargin
 

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ScanGraphAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ScanGraphAcceptanceTest.scala
@@ -26,8 +26,11 @@
  */
 package org.opencypher.spark.impl.acceptance
 
+import org.junit.runner.RunWith
 import org.scalatest.Suites
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class ScanGraphAcceptanceTest extends Suites(
   Aggregation_ScanGraph,
   BoundedVarExpand_ScanGraph,

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/SingleTableGraphAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/SingleTableGraphAcceptanceTest.scala
@@ -26,8 +26,11 @@
  */
 package org.opencypher.spark.impl.acceptance
 
+import org.junit.runner.RunWith
 import org.scalatest.Suites
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class SingleTableGraphAcceptanceTest extends Suites(
   Aggregation_SingleTableGraph,
   BoundedVarExpand_SingleTableGraph,

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/table/CAPSRecordHeaderTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/table/CAPSRecordHeaderTest.scala
@@ -26,14 +26,14 @@
  */
 package org.opencypher.spark.impl.table
 
-import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, StringType, StructField}
 import org.opencypher.okapi.api.types.{CTList, CTString}
 import org.opencypher.okapi.ir.api.expr.Var
 import org.opencypher.okapi.relational.impl.table.RecordHeader
+import org.opencypher.okapi.testing.BaseTestSuite
 import org.opencypher.spark.impl.convert.SparkConversions._
-import org.scalatest.{FunSpec, Matchers}
 
-class CAPSRecordHeaderTest extends FunSpec with Matchers {
+class CAPSRecordHeaderTest extends BaseTestSuite {
 
   it("computes a struct type from a given record header") {
     val header = RecordHeader.empty

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/table/CAPSStructTypeTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/table/CAPSStructTypeTest.scala
@@ -30,10 +30,10 @@ import org.apache.spark.sql.types._
 import org.opencypher.okapi.api.types.{CTInteger, CTList, CTString}
 import org.opencypher.okapi.ir.api.expr.Var
 import org.opencypher.okapi.relational.impl.table.RecordHeader
+import org.opencypher.okapi.testing.BaseTestSuite
 import org.opencypher.spark.impl.convert.SparkConversions._
-import org.scalatest.{FunSpec, Matchers}
 
-class CAPSStructTypeTest extends FunSpec with Matchers {
+class CAPSStructTypeTest extends BaseTestSuite {
 
   it("computes a header from a given struct type") {
     val structType = StructType(Seq(

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/util/AnnotationTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/util/AnnotationTest.scala
@@ -26,8 +26,8 @@
  */
 package org.opencypher.spark.impl.util
 
+import org.opencypher.okapi.testing.BaseTestSuite
 import org.opencypher.spark.api.io.{Labels, Node, Relationship, RelationshipType}
-import org.scalatest.{FunSuite, Matchers}
 
 import scala.annotation.StaticAnnotation
 
@@ -50,7 +50,7 @@ case class RelWithAnnotation(id: Long, source: Long, target: Long) extends Relat
 @TestAnnotation("Foo")
 case class TestAnnotation(foo: String) extends StaticAnnotation
 
-class AnnotationTest extends FunSuite with Matchers {
+class AnnotationTest extends BaseTestSuite {
 
   test("read node label annotation") {
     Annotation.labels[NodeWithoutAnnotation] should equal(Set(classOf[NodeWithoutAnnotation].getSimpleName))


### PR DESCRIPTION
Scalatest-maven-plugin is brittle and not maintained (fix is here: https://github.com/scalatest/scalatest-maven-plugin/pull/43 but not merged).

NOTE: We now have to always extend `BaseTestSuite`, `CAPSTestSuite` or add a `@RunWith(classOf[JUnitRunner])` in order for surefire to pick up the tests and run them (with JUnit4).