### PR TITLE
Implementing trigonometric functions

### DIFF
--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -830,6 +830,63 @@ final case class Sign(expr: Expr)(val cypherType: CypherType = CTWildcard) exten
   override def withCypherType(ct: CypherType): Sign = copy()(ct)
 }
 
+// Trigonometric functions
+
+final case class Acos(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Acos
+  override def withCypherType(ct: CypherType): Acos = copy()(ct)
+}
+
+final case class Asin(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Asin
+  override def withCypherType(ct: CypherType): Asin = copy()(ct)
+}
+
+final case class Atan(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Atan
+  override def withCypherType(ct: CypherType): Atan = copy()(ct)
+}
+
+//Todo: Atan2;  cot and haversine (not supported in spark) but possible via workarounds? (f.i. cot a = 1/(tan a))
+
+
+final case class Cos(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Cos
+  override def withCypherType(ct: CypherType): Cos = copy()(ct)
+}
+
+final case class Cot(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Cot
+  override def withCypherType(ct: CypherType): Cot = copy()(ct)
+}
+
+final case class Degrees(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Degrees
+  override def withCypherType(ct: CypherType): Degrees = copy()(ct)
+}
+
+final case class Haversin(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Haversin
+  override def withCypherType(ct: CypherType): Haversin = copy()(ct)
+}
+
+final case class Radians(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Radians
+  override def withCypherType(ct: CypherType): Radians = copy()(ct)
+}
+
+final case class Sin(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Sin
+  override def withCypherType(ct: CypherType): Sin = copy()(ct)
+}
+
+final case class Tan(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
+  override type This = Tan
+  override def withCypherType(ct: CypherType): Tan = copy()(ct)
+}
+
+
+
 // Time functions
 
 final case class Timestamp()(val cypherType: CypherType = CTWildcard) extends NullaryFunctionExpr {

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -847,8 +847,11 @@ final case class Atan(expr: Expr)(val cypherType: CypherType = CTWildcard) exten
   override def withCypherType(ct: CypherType): Atan = copy()(ct)
 }
 
-//Todo: Atan2;  cot and haversine (not supported in spark) but possible via workarounds? (f.i. cot a = 1/(tan a))
-
+final case class Atan2(expr1: Expr, expr2: Expr)(val cypherType: CypherType = CTWildcard) extends FunctionExpr {
+  override type This = Atan2
+  override def withCypherType(ct: CypherType): Atan2 = copy()(ct)
+  override def exprs: IndexedSeq[Expr] = IndexedSeq(expr1,expr2)
+}
 
 final case class Cos(expr: Expr)(val cypherType: CypherType = CTWildcard) extends UnaryFunctionExpr {
   override type This = Cos

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/FunctionUtils.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/FunctionUtils.scala
@@ -83,6 +83,18 @@ object FunctionUtils {
         case functions.Round => Round(expr.head)(cypherType)
         case functions.Sign => Sign(expr.head)(cypherType)
 
+        // Trigonometric functions
+        case functions.Acos => Acos(expr.head)(cypherType)
+        case functions.Asin => Asin(expr.head)(cypherType)
+        case functions.Atan => Atan(expr.head)(cypherType)
+        case functions.Cos => Cos(expr.head)(cypherType)
+        case functions.Cot => Cot(expr.head)(cypherType)
+        case functions.Degrees => Degrees(expr.head)(cypherType)
+        case functions.Haversin => Haversin(expr.head)(cypherType)
+        case functions.Radians => Radians(expr.head)(cypherType)
+        case functions.Sin => Sin(expr.head)(cypherType)
+        case functions.Tan => Tan(expr.head)(cypherType)
+
         // Match by name
         case functions.UnresolvedFunction => functionInvocation.name match {
           // Time functions

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/FunctionUtils.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/FunctionUtils.scala
@@ -87,6 +87,7 @@ object FunctionUtils {
         case functions.Acos => Acos(expr.head)(cypherType)
         case functions.Asin => Asin(expr.head)(cypherType)
         case functions.Atan => Atan(expr.head)(cypherType)
+        case functions.Atan2 => Atan2(expr(0),expr(1))(cypherType)
         case functions.Cos => Cos(expr.head)(cypherType)
         case functions.Cot => Cot(expr.head)(cypherType)
         case functions.Degrees => Degrees(expr.head)(cypherType)

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/typer/SchemaTyper.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/typer/SchemaTyper.scala
@@ -39,7 +39,7 @@ import org.opencypher.okapi.ir.impl.parse.functions.Timestamp
 import org.opencypher.okapi.ir.impl.parse.rewriter.ExistsPattern
 import org.opencypher.okapi.ir.impl.typer.SignatureConverter._
 import org.opencypher.v9_0.expressions._
-import org.opencypher.v9_0.expressions.functions.{Abs, Ceil, Coalesce, Collect, Exists, Exp, Floor, Keys, Log, Log10, Max, Min, Properties, Round, Sign, Sqrt, ToBoolean, ToString, UnresolvedFunction}
+import org.opencypher.v9_0.expressions.functions.{Abs, Acos, Asin, Atan, Ceil, Coalesce, Collect, Cos, Cot, Degrees, Exists, Exp, Floor, Haversin, Keys, Log, Log10, Max, Min, Properties, Radians, Round, Sign, Sin, Sqrt, Tan, ToBoolean, ToString, UnresolvedFunction}
 
 final case class SchemaTyper(schema: Schema) {
 
@@ -570,6 +570,16 @@ object SchemaTyper {
               FunctionSignature(Seq(CTFloat), CTInteger),
               FunctionSignature(Seq(CTInteger), CTInteger)
             ))
+
+        //todo: could also be unioned in the cases above? (also maybe add tests for this cases?)
+        case Acos | Asin | Atan | Cos | Cot | Degrees | Haversin | Radians | Sin | Tan =>
+          pure[R, Set[FunctionSignature]](
+            Set(
+              FunctionSignature(Seq(CTNull), CTNull),
+              FunctionSignature(Seq(CTFloat), CTFloat),
+              FunctionSignature(Seq(CTInteger), CTFloat)
+            ))
+
         case f: TypeSignatures =>
           val set = f.signatures.flatMap(_.convert).toSet
           pure(set)

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/typer/SchemaTyper.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/typer/SchemaTyper.scala
@@ -39,7 +39,7 @@ import org.opencypher.okapi.ir.impl.parse.functions.Timestamp
 import org.opencypher.okapi.ir.impl.parse.rewriter.ExistsPattern
 import org.opencypher.okapi.ir.impl.typer.SignatureConverter._
 import org.opencypher.v9_0.expressions._
-import org.opencypher.v9_0.expressions.functions.{Abs, Acos, Asin, Atan, Ceil, Coalesce, Collect, Cos, Cot, Degrees, Exists, Exp, Floor, Haversin, Keys, Log, Log10, Max, Min, Properties, Radians, Round, Sign, Sin, Sqrt, Tan, ToBoolean, ToString, UnresolvedFunction}
+import org.opencypher.v9_0.expressions.functions.{Abs, Acos, Asin, Atan, Atan2, Ceil, Coalesce, Collect, Cos, Cot, Degrees, Exists, Exp, Floor, Haversin, Keys, Log, Log10, Max, Min, Properties, Radians, Round, Sign, Sin, Sqrt, Tan, ToBoolean, ToString, UnresolvedFunction}
 
 final case class SchemaTyper(schema: Schema) {
 
@@ -571,13 +571,27 @@ object SchemaTyper {
               FunctionSignature(Seq(CTInteger), CTInteger)
             ))
 
-        //todo: could also be unioned in the cases above? (also maybe add tests for this cases?)
+        //todo: could also be unioned with the cases above? (also maybe add tests for these cases?)
         case Acos | Asin | Atan | Cos | Cot | Degrees | Haversin | Radians | Sin | Tan =>
           pure[R, Set[FunctionSignature]](
             Set(
               FunctionSignature(Seq(CTNull), CTNull),
               FunctionSignature(Seq(CTFloat), CTFloat),
               FunctionSignature(Seq(CTInteger), CTFloat)
+            ))
+
+        case Atan2 =>
+          pure[R, Set[FunctionSignature]](
+            Set(
+              FunctionSignature(Seq(CTNull, CTNull), CTNull),
+              FunctionSignature(Seq(CTNull, CTFloat), CTNull),
+              FunctionSignature(Seq(CTFloat, CTNull), CTNull),
+              FunctionSignature(Seq(CTFloat, CTFloat), CTFloat),
+              FunctionSignature(Seq(CTFloat, CTInteger), CTFloat),
+              FunctionSignature(Seq(CTInteger, CTFloat), CTFloat),
+              FunctionSignature(Seq(CTInteger, CTInteger), CTFloat),
+              FunctionSignature(Seq(CTNull, CTInteger), CTNull),
+              FunctionSignature(Seq(CTInteger, CTNull), CTNull)
             ))
 
         case f: TypeSignatures =>

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
@@ -18,10 +18,10 @@
  * This work was created by the collective efforts of the openCypher community.
  * Without limiting the terms of Section 6, any Derivative Work that is not
  * approved by the public consensus process of the openCypher Implementers Group
- * should not be described AS “Cypher” (and Cypher® is a registered trademark of
- * Neo4j Inc.) or AS "openCypher". Extensions by implementers or prototypes or
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
  * proposals for change that have been documented or implemented should only be
- * described AS "implementation extensions to Cypher" or AS "proposed changes to
+ * described as "implementation extensions to Cypher" or as "proposed changes to
  * Cypher that are not yet approved by the openCypher community".
  */
 package org.opencypher.spark.impl.acceptance
@@ -568,7 +568,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("size() on literal list") {
       val given = initGraph("CREATE ()")
 
-      val result = given.cypher("MATCH () RETURN size(['Alice', 'Bob']) AS s")
+      val result = given.cypher("MATCH () RETURN size(['Alice', 'Bob']) As s")
 
       result.records.toMaps should equal(
         Bag(

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
@@ -18,10 +18,10 @@
  * This work was created by the collective efforts of the openCypher community.
  * Without limiting the terms of Section 6, any Derivative Work that is not
  * approved by the public consensus process of the openCypher Implementers Group
- * should not be described as “Cypher” (and Cypher® is a registered trademark of
- * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * should not be described AS “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or AS "openCypher". Extensions by implementers or prototypes or
  * proposals for change that have been documented or implemented should only be
- * described as "implementation extensions to Cypher" or as "proposed changes to
+ * described AS "implementation extensions to Cypher" or AS "proposed changes to
  * Cypher that are not yet approved by the openCypher community".
  */
 package org.opencypher.spark.impl.acceptance
@@ -38,7 +38,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Acos"){
     it("on int value") {
-      val result = caps.cypher("Return acos(1) as res")
+      val result = caps.cypher("RETURN acos(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.0)
@@ -47,7 +47,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return acos(0.5) as res")
+      val result = caps.cypher("RETURN acos(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 1.0471975511965979)
@@ -56,7 +56,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return acos(null) as res")
+      val result = caps.cypher("RETURN acos(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -67,7 +67,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Asin"){
     it("on int value") {
-      val result = caps.cypher("Return asin(1) as res")
+      val result = caps.cypher("RETURN asin(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 1.5707963267948966)
@@ -76,7 +76,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return asin(0.5) as res")
+      val result = caps.cypher("RETURN asin(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.5235987755982989)
@@ -85,7 +85,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return asin(null) as res")
+      val result = caps.cypher("RETURN asin(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -96,7 +96,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Atan"){
     it("on int value") {
-      val result = caps.cypher("Return atan(1) as res")
+      val result = caps.cypher("RETURN atan(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.7853981633974483)
@@ -105,7 +105,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return atan(0.5) as res")
+      val result = caps.cypher("RETURN atan(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.4636476090008061)
@@ -114,7 +114,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return atan(null) as res")
+      val result = caps.cypher("RETURN atan(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -125,7 +125,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Atan2"){
     it("on int values") {
-      val result = caps.cypher("Return atan2(1,2) as res")
+      val result = caps.cypher("RETURN atan2(1,2) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.4636476090008061)
@@ -134,7 +134,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float values") {
-      val result = caps.cypher("Return atan2(0.5,0.6) as res")
+      val result = caps.cypher("RETURN atan2(0.5,0.6) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.6947382761967033)
@@ -143,7 +143,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on two null values") {
-      val result = caps.cypher("Return atan2(null,null) as res")
+      val result = caps.cypher("RETURN atan2(null,null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -152,7 +152,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on first value being null") {
-      val result = caps.cypher("Return atan2(null,0.5) as res")
+      val result = caps.cypher("RETURN atan2(null,0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -161,7 +161,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on second value being null") {
-      val result = caps.cypher("Return atan2(0.5, null) as res")
+      val result = caps.cypher("RETURN atan2(0.5, null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -172,7 +172,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Cos"){
     it("on int value") {
-      val result = caps.cypher("Return cos(1) as res")
+      val result = caps.cypher("RETURN cos(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.5403023058681398)
@@ -181,7 +181,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return cos(0.5) as res")
+      val result = caps.cypher("RETURN cos(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.8775825618903728)
@@ -190,7 +190,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return cos(null) as res")
+      val result = caps.cypher("RETURN cos(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -201,7 +201,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Cot"){
     it("on int value") {
-      val result = caps.cypher("Return cot(1) as res")
+      val result = caps.cypher("RETURN cot(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.6420926159343306)
@@ -210,7 +210,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return cot(0.5) as res")
+      val result = caps.cypher("RETURN cot(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 1.830487721712452)
@@ -219,7 +219,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return cot(null) as res")
+      val result = caps.cypher("RETURN cot(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -230,7 +230,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Degrees"){
     it("on int value") {
-      val result = caps.cypher("Return degrees(1) as res")
+      val result = caps.cypher("RETURN degrees(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 57.29577951308232)
@@ -239,7 +239,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return degrees(3.14159) as res")
+      val result = caps.cypher("RETURN degrees(3.14159) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 179.99984796050427)
@@ -248,7 +248,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return degrees(null) as res")
+      val result = caps.cypher("RETURN degrees(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -259,7 +259,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Haversin"){
     it("on int value") {
-      val result = caps.cypher("Return haversin(1) as res")
+      val result = caps.cypher("RETURN haversin(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.22984884706593012)
@@ -268,7 +268,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return haversin(0.5) as res")
+      val result = caps.cypher("RETURN haversin(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.06120871905481362)
@@ -277,7 +277,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return haversin(null) as res")
+      val result = caps.cypher("RETURN haversin(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -288,7 +288,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Radians"){
     it("on int value") {
-      val result = caps.cypher("Return radians(180) as res")
+      val result = caps.cypher("RETURN radians(180) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 3.141592653589793)
@@ -297,7 +297,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return radians(180.0) as res")
+      val result = caps.cypher("RETURN radians(180.0) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 3.141592653589793)
@@ -306,7 +306,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return radians(null) as res")
+      val result = caps.cypher("RETURN radians(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -317,7 +317,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("Sin"){
     it("on int value") {
-      val result = caps.cypher("Return sin(1) as res")
+      val result = caps.cypher("RETURN sin(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.8414709848078965)
@@ -326,7 +326,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return sin(0.5) as res")
+      val result = caps.cypher("RETURN sin(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.479425538604203)
@@ -335,7 +335,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return sin(null) as res")
+      val result = caps.cypher("RETURN sin(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -346,7 +346,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("tan"){
     it("on int value") {
-      val result = caps.cypher("Return tan(1) as res")
+      val result = caps.cypher("RETURN tan(1) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 1.5574077246549023)
@@ -355,7 +355,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on float value") {
-      val result = caps.cypher("Return tan(0.5) as res")
+      val result = caps.cypher("RETURN tan(0.5) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> 0.5463024898437905)
@@ -364,7 +364,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
 
     it("on null value") {
-      val result = caps.cypher("Return tan(null) as res")
+      val result = caps.cypher("RETURN tan(null) AS res")
       result.records.toMaps should equal(
         Bag(
           CypherMap("res" -> null)
@@ -375,7 +375,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("toUpper") {
     it("toUpper()") {
-      val result = caps.cypher("Return toUpper('hello') as upperCased")
+      val result = caps.cypher("RETURN toUpper('hello') AS upperCased")
       result.records.toMaps should equal(
         Bag(
           CypherMap("upperCased" -> "HELLO")
@@ -386,7 +386,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
   describe("toLower") {
     it("toLower()") {
-      val result = caps.cypher("Return toLower('HELLO') as lowerCased")
+      val result = caps.cypher("RETURN toLower('HELLO') AS lowerCased")
       result.records.toMaps should equal(
         Bag(
           CypherMap("lowerCased" -> "hello")
@@ -568,7 +568,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("size() on literal list") {
       val given = initGraph("CREATE ()")
 
-      val result = given.cypher("MATCH () RETURN size(['Alice', 'Bob']) as s")
+      val result = given.cypher("MATCH () RETURN size(['Alice', 'Bob']) AS s")
 
       result.records.toMaps should equal(
         Bag(
@@ -579,7 +579,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("size() on literal string") {
       val given = initGraph("CREATE ()")
 
-      val result = given.cypher("MATCH () RETURN size('Alice') as s")
+      val result = given.cypher("MATCH () RETURN size('Alice') AS s")
 
       result.records.toMaps should equal(
         Bag(
@@ -590,7 +590,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("size() on retrieved string") {
       val given = initGraph("CREATE ({name: 'Alice'})")
 
-      val result = given.cypher("MATCH (a) RETURN size(a.name) as s")
+      val result = given.cypher("MATCH (a) RETURN size(a.name) AS s")
 
       result.records.toMaps should equal(
         Bag(
@@ -601,7 +601,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("size() on constructed list") {
       val given = initGraph("CREATE (:A:B), (:C:D), (:A), ()")
 
-      val result = given.cypher("MATCH (a) RETURN size(labels(a)) as s")
+      val result = given.cypher("MATCH (a) RETURN size(labels(a)) AS s")
 
       result.records.toMaps should equal(
         Bag(
@@ -615,7 +615,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     ignore("size() on null") {
       val given = initGraph("CREATE ()")
 
-      val result = given.cypher("MATCH (a) RETURN size(a.prop) as s")
+      val result = given.cypher("MATCH (a) RETURN size(a.prop) AS s")
 
       result.records.toMaps should equal(Bag(CypherMap("s" -> null)))
     }
@@ -627,7 +627,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("keys()") {
       val given = initGraph("CREATE ({name:'Alice', age: 64, eyes:'brown'})")
 
-      val result = given.cypher("MATCH (a) WHERE a.name = 'Alice' RETURN keys(a) as k")
+      val result = given.cypher("MATCH (a) WHERE a.name = 'Alice' RETURN keys(a) AS k")
 
       val keysAsMap = result.records.toMaps
 
@@ -644,7 +644,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
           |CREATE (:Person {name:'Bob', eyes:'blue'})
         """.stripMargin)
 
-      val result = given.cypher("MATCH (a: Person) WHERE a.name = 'Bob' RETURN keys(a) as k")
+      val result = given.cypher("MATCH (a: Person) WHERE a.name = 'Bob' RETURN keys(a) AS k")
 
       result.records.toMaps should equal(
         Bag(
@@ -656,7 +656,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
       val result = caps.cypher(
         """
           |WITH {person: {name: 'Anne', age: 25}} AS p
-          |RETURN keys(p) as k1, keys(p["person"]) as k2
+          |RETURN keys(p) AS k1, keys(p["person"]) AS k2
         """.stripMargin)
 
       result.records.toMaps should equal(
@@ -700,8 +700,8 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
           |] AS value
           |WITH {
           | key: value
-          |} as map
-          |RETURN keys(map) as k
+          |} AS map
+          |RETURN keys(map) AS k
         """.stripMargin)
 
       result.records.toMaps should equal(
@@ -747,7 +747,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("toFloat from integers") {
       val given = initGraph("CREATE (a {val: 1})")
 
-      val result = given.cypher("MATCH (a) RETURN toFloat(a.val) as myFloat")
+      val result = given.cypher("MATCH (a) RETURN toFloat(a.val) AS myFloat")
 
       result.records.toMaps should equal(
         Bag(
@@ -758,7 +758,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("toFloat from float") {
       val given = initGraph("CREATE (a {val: 1.0d})")
 
-      val result = given.cypher("MATCH (a) RETURN toFloat(a.val) as myFloat")
+      val result = given.cypher("MATCH (a) RETURN toFloat(a.val) AS myFloat")
 
       result.records.toMaps should equal(
         Bag(
@@ -769,7 +769,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("toFloat from string") {
       val given = initGraph("CREATE (a {val: '42'})")
 
-      val result = given.cypher("MATCH (a) RETURN toFloat(a.val) as myFloat")
+      val result = given.cypher("MATCH (a) RETURN toFloat(a.val) AS myFloat")
 
       result.records.toMaps should equal(
         Bag(
@@ -904,7 +904,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("can evaluate coalesce") {
       val given = initGraph("CREATE ({valA: 1}), ({valB: 2}), ({valC: 3}), ()")
 
-      val result = given.cypher("MATCH (n) RETURN coalesce(n.valA, n.valB, n.valC) as value")
+      val result = given.cypher("MATCH (n) RETURN coalesce(n.valA, n.valB, n.valC) AS value")
 
       result.records.collect.toBag should equal(
         Bag(
@@ -918,7 +918,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     it("can evaluate coalesce on non-existing expressions") {
       val given = initGraph("CREATE ({valA: 1}), ({valB: 2}), ()")
 
-      val result = given.cypher("MATCH (n) RETURN coalesce(n.valD, n.valE) as value")
+      val result = given.cypher("MATCH (n) RETURN coalesce(n.valD, n.valE) AS value")
 
       result.records.collect.toBag should equal(
         Bag(
@@ -1364,7 +1364,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
       g.cypher(
         """
           |MATCH (n)
-          |RETURN range(n.from, n.to) as x""".stripMargin).records.toMaps should equal(Bag(
+          |RETURN range(n.from, n.to) AS x""".stripMargin).records.toMaps should equal(Bag(
         CypherMap("x" -> List(1, 2)),
         CypherMap("x" -> List(1, 2, 3)),
         CypherMap("x" -> List(1, 2, 3, 4))
@@ -1381,7 +1381,7 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
       g.cypher(
         """
           |MATCH (n)
-          |RETURN range(1, 4, n.step) as x""".stripMargin).records.toMaps should equal(Bag(
+          |RETURN range(1, 4, n.step) AS x""".stripMargin).records.toMaps should equal(Bag(
         CypherMap("x" -> List(1, 3)),
         CypherMap("x" -> List(1, 4))
       ))

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
@@ -123,6 +123,53 @@ class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
     }
   }
 
+  describe("Atan2"){
+    it("on int values") {
+      val result = caps.cypher("Return atan2(1,2) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.4636476090008061)
+        )
+      )
+    }
+
+    it("on float values") {
+      val result = caps.cypher("Return atan2(0.5,0.6) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.6947382761967033)
+        )
+      )
+    }
+
+    it("on two null values") {
+      val result = caps.cypher("Return atan2(null,null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+
+    it("on first value being null") {
+      val result = caps.cypher("Return atan2(null,0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+
+    it("on second value being null") {
+      val result = caps.cypher("Return atan2(0.5, null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
   describe("Cos"){
     it("on int value") {
       val result = caps.cypher("Return cos(1) as res")

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionsBehaviour.scala
@@ -36,6 +36,296 @@ import org.scalatest.DoNotDiscover
 @DoNotDiscover
 class FunctionsBehaviour extends CAPSTestSuite with DefaultGraphInit {
 
+  describe("Acos"){
+    it("on int value") {
+      val result = caps.cypher("Return acos(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.0)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return acos(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 1.0471975511965979)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return acos(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Asin"){
+    it("on int value") {
+      val result = caps.cypher("Return asin(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 1.5707963267948966)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return asin(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.5235987755982989)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return asin(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Atan"){
+    it("on int value") {
+      val result = caps.cypher("Return atan(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.7853981633974483)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return atan(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.4636476090008061)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return atan(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Cos"){
+    it("on int value") {
+      val result = caps.cypher("Return cos(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.5403023058681398)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return cos(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.8775825618903728)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return cos(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Cot"){
+    it("on int value") {
+      val result = caps.cypher("Return cot(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.6420926159343306)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return cot(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 1.830487721712452)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return cot(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Degrees"){
+    it("on int value") {
+      val result = caps.cypher("Return degrees(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 57.29577951308232)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return degrees(3.14159) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 179.99984796050427)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return degrees(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Haversin"){
+    it("on int value") {
+      val result = caps.cypher("Return haversin(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.22984884706593012)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return haversin(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.06120871905481362)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return haversin(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Radians"){
+    it("on int value") {
+      val result = caps.cypher("Return radians(180) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 3.141592653589793)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return radians(180.0) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 3.141592653589793)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return radians(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("Sin"){
+    it("on int value") {
+      val result = caps.cypher("Return sin(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.8414709848078965)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return sin(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.479425538604203)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return sin(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
+  describe("tan"){
+    it("on int value") {
+      val result = caps.cypher("Return tan(1) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 1.5574077246549023)
+        )
+      )
+    }
+
+    it("on float value") {
+      val result = caps.cypher("Return tan(0.5) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> 0.5463024898437905)
+        )
+      )
+    }
+
+    it("on null value") {
+      val result = caps.cypher("Return tan(null) as res")
+      result.records.toMaps should equal(
+        Bag(
+          CypherMap("res" -> null)
+        )
+      )
+    }
+  }
+
   describe("toUpper") {
     it("toUpper()") {
       val result = caps.cypher("Return toUpper('hello') as upperCased")

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
@@ -321,6 +321,7 @@ object SparkSQLExprMapper {
         case Acos(e) => functions.acos(e.asSparkSQLExpr)
         case Asin(e) => functions.asin(e.asSparkSQLExpr)
         case Atan(e) => functions.atan(e.asSparkSQLExpr)
+        case Atan2(e1,e2) => functions.atan2(e1.asSparkSQLExpr, e2.asSparkSQLExpr)
         case Cos(e) => functions.cos(e.asSparkSQLExpr)
         case Cot(e) => Divide(IntegerLit(1)(CTInteger), Tan(e)(CTFloat))(CTFloat).asSparkSQLExpr
         case Degrees(e) => functions.degrees(e.asSparkSQLExpr)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
@@ -318,6 +318,18 @@ object SparkSQLExprMapper {
         case Round(e) => functions.round(e.asSparkSQLExpr).cast(DoubleType)
         case Sign(e) => functions.signum(e.asSparkSQLExpr).cast(IntegerType)
 
+        case Acos(e) => functions.acos(e.asSparkSQLExpr)
+        case Asin(e) => functions.asin(e.asSparkSQLExpr)
+        case Atan(e) => functions.atan(e.asSparkSQLExpr)
+        case Cos(e) => functions.cos(e.asSparkSQLExpr)
+        case Cot(e) => Divide(IntegerLit(1)(CTInteger), Tan(e)(CTFloat))(CTFloat).asSparkSQLExpr
+        case Degrees(e) => functions.degrees(e.asSparkSQLExpr)
+        case Haversin(e) => Divide(Subtract(IntegerLit(1)(CTInteger),Cos(e)(CTFloat))(CTFloat), IntegerLit(2)(CTInteger))(CTFloat).asSparkSQLExpr
+        case Radians(e) => functions.radians(e.asSparkSQLExpr)
+        case Sin(e) => functions.sin(e.asSparkSQLExpr)
+        case Tan(e) => functions.tan(e.asSparkSQLExpr)
+
+
         // Time functions
 
         case Timestamp() => functions.current_timestamp().cast(LongType)


### PR DESCRIPTION
* functions that are currently not supported in spark are evaluated based on existing functions (*haversin()* and *cot()*). 
 