### PR TITLE
Migrate parsers for DDL and Cypher types to FastParse 2.1.0

### DIFF
--- a/build.params.gradle
+++ b/build.params.gradle
@@ -20,7 +20,7 @@ ext {
 
             spark       : '2.2.3',
             hadoop      : '2.7.0',
-            fastparse   : '1.0.0',
+            fastparse   : '2.1.0',
             upickle     : '0.6.6',
             cats        : '1.0.1',
             eff         : '5.0.0',

--- a/graph-ddl/LICENSES.txt
+++ b/graph-ddl/LICENSES.txt
@@ -261,10 +261,9 @@ MIT
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/graph-ddl/NOTICE.txt
+++ b/graph-ddl/NOTICE.txt
@@ -52,9 +52,8 @@ MIT
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar

--- a/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdl.scala
+++ b/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdl.scala
@@ -41,7 +41,7 @@ object GraphDdl {
   type PropertyMappings = Map[String, String]
 
   def apply(ddl: String): GraphDdl =
-    GraphDdl(GraphDdlParser.parse(ddl))
+    GraphDdl(GraphDdlParser.parseDdl(ddl))
 
   def apply(ddl: DdlDefinition): GraphDdl = {
 

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlAcceptanceTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlAcceptanceTest.scala
@@ -246,7 +246,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
     }
 
     it("parses correct schema") {
-      val ddlDefinition: DdlDefinition = parse(
+      val ddlDefinition: DdlDefinition = parseDdl(
         s"""|SET SCHEMA foo.bar;
             |
             |CREATE ELEMENT TYPE A ( name STRING )
@@ -332,7 +332,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
     }
 
     it("creates implicit node/edge types from mappings") {
-      val ddlDefinition: DdlDefinition = parse(
+      val ddlDefinition: DdlDefinition = parseDdl(
         s"""|SET SCHEMA a.b;
             |
             |CREATE GRAPH $graphName (
@@ -361,7 +361,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
     }
 
     it("resolves element types from parent graph type") {
-      val ddlDefinition: DdlDefinition = parse(
+      val ddlDefinition: DdlDefinition = parseDdl(
         s"""|SET SCHEMA a.b;
             |
             |CREATE GRAPH TYPE $typeName (
@@ -392,7 +392,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
     }
 
     it("resolves shadowed element types") {
-      val ddlDefinition: DdlDefinition = parse(
+      val ddlDefinition: DdlDefinition = parseDdl(
         s"""|SET SCHEMA a.b;
             |
             |CREATE GRAPH TYPE $typeName (
@@ -425,7 +425,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
     }
 
     it("resolves most local element type") {
-      val ddlDefinition: DdlDefinition = parse(
+      val ddlDefinition: DdlDefinition = parseDdl(
         s"""|SET SCHEMA a.b;
             |
             |CREATE ELEMENT TYPE X (a STRING)
@@ -469,7 +469,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
 
 
     it("throws if a label is not defined") {
-      val ddlDefinition = parse(
+      val ddlDefinition = parseDdl(
         s"""|CREATE ELEMENT TYPE A
             |
             |CREATE GRAPH TYPE $typeName (
@@ -488,7 +488,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
     }
 
     it("throws if a relationship type is not defined") {
-      val ddlDefinition = parse(
+      val ddlDefinition = parseDdl(
         s"""|CREATE ELEMENT TYPE A
             |
             |CREATE GRAPH TYPE $typeName (
@@ -514,7 +514,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
             |""".stripMargin
 
       an[GraphDdlException] shouldBe thrownBy {
-        GraphDdl(parse(ddlString)).graphs(graphName).graphType
+        GraphDdl(parseDdl(ddlString)).graphs(graphName).graphType
       }
     }
 
@@ -530,7 +530,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
             |""".stripMargin
 
       an[GraphDdlException] shouldBe thrownBy {
-        GraphDdl(parse(ddlString)).graphs(graphName).graphType
+        GraphDdl(parseDdl(ddlString)).graphs(graphName).graphType
       }
     }
   }

--- a/okapi-api/LICENSES.txt
+++ b/okapi-api/LICENSES.txt
@@ -261,10 +261,9 @@ MIT
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/okapi-api/NOTICE.txt
+++ b/okapi-api/NOTICE.txt
@@ -52,9 +52,8 @@ MIT
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/types/CypherType.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/types/CypherType.scala
@@ -49,7 +49,7 @@ object CypherType {
     * @see {{{org.opencypher.okapi.api.types.CypherType#name}}}
     */
   def fromName(name: String): Option[CypherType] = {
-   CypherTypeParser.parse(name)
+   CypherTypeParser.parseCypherType(name)
   }
 
   implicit class TypeCypherValue(cv: CypherValue) {

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/types/CypherTypeParser.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/types/CypherTypeParser.scala
@@ -26,78 +26,90 @@
  */
 package org.opencypher.okapi.impl.types
 
-import fastparse.core.Parsed.{Failure, Success}
+import fastparse.Parsed.{Failure, Success}
 import org.apache.logging.log4j.scala.Logging
 import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.impl.util.ParserUtils._
+import fastparse._
 
-//noinspection ForwardReference
 object CypherTypeParser extends Logging {
 
-  def parse(input: String): Option[CypherType] = {
-    cypherType.entireInput.parse(input) match {
+  def parseCypherType(input: String): Option[CypherType] = {
+    parse(input, cypherTypeFromEntireInput(_)) match {
       case Success(value, _) => Some(value)
-      case Failure(_, index, extra) =>
-        logger.debug(s"Failed to parse $input at index $index: ${extra.traced.trace}")
+      case Failure(expected, index, extra) =>
+        val before = index - math.max(index - 20, 0)
+        val after = math.min(index + 20, extra.input.length) - index
+        val locationPointer =
+          s"""|\t${extra.input.slice(index - before, index + after).replace('\n', ' ')}
+              |\t${"~" * before + "^" + "~" * after}
+           """.stripMargin
+        val msg =
+          s"""|Failed at index $index:
+              |
+              |Expected:\t$expected
+              |
+              |$locationPointer
+              |
+              |${extra.trace().msg}""".stripMargin
+        logger.debug(msg)
         None
     }
   }
 
-  import fastparse.noApi._
-  import org.opencypher.okapi.impl.util.ParserUtils.Whitespace._
-  import org.opencypher.okapi.impl.util.ParserUtils._
-
   // Basic types
-  val STRING: P[CTString.type] = IgnoreCase("STRING").map(_ => CTString)
-  val INTEGER: P[CTInteger.type] = IgnoreCase("INTEGER").map(_ => CTInteger)
-  val FLOAT: P[CTFloat.type] = IgnoreCase("FLOAT").map(_ => CTFloat)
-  val NUMBER: P[CTNumber.type] = IgnoreCase("NUMBER").map(_ => CTNumber)
-  val BOOLEAN: P[CTBoolean.type] = IgnoreCase("BOOLEAN").map(_ => CTBoolean)
-  val ANY: P[CTAny.type] = IgnoreCase("ANY").map(_ => CTAny)
-  val VOID: P[CTVoid.type] = IgnoreCase("VOID").map(_ => CTVoid)
-  val NULL: P[CTNull.type] = IgnoreCase("NULL").map(_ => CTNull)
-  val WILDCARD: P[CTWildcard.type] = IgnoreCase("?").map(_ => CTWildcard)
-  val DATE: P[CTDate.type] = IgnoreCase("DATE").map(_ => CTDate)
-  val DATETIME: P[CTDateTime.type] = IgnoreCase("DATETIME").map(_ => CTDateTime)
+  def STRING[_: P]: P[CTString.type] = IgnoreCase("STRING").map(_ => CTString)
+  def INTEGER[_: P]: P[CTInteger.type] = IgnoreCase("INTEGER").map(_ => CTInteger)
+  def FLOAT[_: P]: P[CTFloat.type] = IgnoreCase("FLOAT").map(_ => CTFloat)
+  def NUMBER[_: P]: P[CTNumber.type] = IgnoreCase("NUMBER").map(_ => CTNumber)
+  def BOOLEAN[_: P]: P[CTBoolean.type] = IgnoreCase("BOOLEAN").map(_ => CTBoolean)
+  def ANY[_: P]: P[CTAny.type] = IgnoreCase("ANY").map(_ => CTAny)
+  def VOID[_: P]: P[CTVoid.type] = IgnoreCase("VOID").map(_ => CTVoid)
+  def NULL[_: P]: P[CTNull.type] = IgnoreCase("NULL").map(_ => CTNull)
+  def WILDCARD[_: P]: P[CTWildcard.type] = IgnoreCase("?").map(_ => CTWildcard)
+  def DATE[_: P]: P[CTDate.type] = IgnoreCase("DATE").map(_ => CTDate)
+  def DATETIME[_: P]: P[CTDateTime.type] = IgnoreCase("DATETIME").map(_ => CTDateTime)
 
   // element types
-  val NODE: P[CTNode] = P(
-    IgnoreCase("NODE") ~ ("(" ~ label.rep() ~ ")").?
+  def NODE[_: P]: P[CTNode] = P(
+    IgnoreCase("NODE") ~/ ("(" ~/ label.rep() ~ ")").?
   ).map(l => CTNode(l.getOrElse(Seq.empty).toSet))
 
-  val RELATIONSHIP: P[CTRelationship] = P(
-    IgnoreCase("RELATIONSHIP") ~ ("(" ~ label.rep(sep = "|") ~ ")").?
+  def RELATIONSHIP[_: P]: P[CTRelationship] = P(
+    IgnoreCase("RELATIONSHIP") ~/ ("(" ~ label.rep(sep = "|") ~/ ")").?
   ).map(l => CTRelationship(l.getOrElse(Seq.empty).toSet))
 
-  val PATH: P[CTPath.type] = IgnoreCase("PATH").map(_ => CTPath)
+  def PATH[_: P]: P[CTPath.type] = P(IgnoreCase("PATH").map(_ => CTPath))
 
   // container types
-  val LIST: P[CTList] = P(IgnoreCase("LIST") ~ "(" ~ cypherType ~ ")").map(inner => CTList(inner))
+  def LIST[_: P]: P[CTList] = P(IgnoreCase("LIST") ~/ "(" ~/ cypherType ~/ ")").map(inner => CTList(inner))
 
-  private val mapKey: P[String] = identifier.! | escapedIdentifier
-  private val kvPair: P[(String, CypherType)] = P(mapKey ~ ":" ~ cypherType)
-  val MAP: P[CTMap] = P(IgnoreCase("MAP") ~ "(" ~ kvPair.rep(sep = ",") ~ ")").map(inner => CTMap(inner.toMap))
+  private def mapKey[_: P]: P[String] = P(identifier.! | escapedIdentifier)
+  private def kvPair[_: P]: P[(String, CypherType)] = P(mapKey ~/ ":" ~/ cypherType)
+  def MAP[_: P]: P[CTMap] = P(IgnoreCase("MAP") ~/ "(" ~/ kvPair.rep(sep = ",") ~/ ")").map(inner => CTMap(inner.toMap))
 
-  val materialCypherType: P[CypherType] = P(
+  def materialCypherType[_: P]: P[CypherType] = P(
     STRING |
-    INTEGER |
-    FLOAT |
-    NUMBER |
-    BOOLEAN |
-    ANY |
-    VOID |
-    NULL |
-    WILDCARD |
-    NODE |
-    RELATIONSHIP |
-    PATH |
-    LIST |
-    MAP |
-    DATETIME | // needs to be infront of date due to shortest match semantics
-    DATE
+      INTEGER |
+      FLOAT |
+      NUMBER |
+      BOOLEAN |
+      ANY |
+      VOID |
+      NULL |
+      WILDCARD |
+      NODE |
+      RELATIONSHIP |
+      PATH |
+      LIST |
+      MAP |
+      DATETIME | // needs to be before date due to shortest match semantics
+      DATE
   )
 
-  val nullableCypherType: P[CypherType] = P(materialCypherType ~ "?").map(ct => ct.nullable)
+  def cypherType[_: P]: P[CypherType] = P((materialCypherType ~ "?".!.?.map(_.isDefined)).map {
+    case (ct, isNullable) => if (isNullable) ct.nullable else ct
+  })
 
-  val cypherType: P[CypherType] = nullableCypherType | materialCypherType
+  def cypherTypeFromEntireInput[_: P]: P[CypherType] = Start ~ cypherType ~ End
 }

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/types/CypherTypeParser.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/types/CypherTypeParser.scala
@@ -35,7 +35,7 @@ import fastparse._
 object CypherTypeParser extends Logging {
 
   def parseCypherType(input: String): Option[CypherType] = {
-    parse(input, cypherTypeFromEntireInput(_)) match {
+    parse(input, cypherTypeFromEntireInput(_), verboseFailures = true) match {
       case Success(value, _) => Some(value)
       case Failure(expected, index, extra) =>
         val before = index - math.max(index - 20, 0)

--- a/okapi-ir/LICENSES.txt
+++ b/okapi-ir/LICENSES.txt
@@ -262,10 +262,9 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/okapi-ir/NOTICE.txt
+++ b/okapi-ir/NOTICE.txt
@@ -53,9 +53,8 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar

--- a/okapi-logical/LICENSES.txt
+++ b/okapi-logical/LICENSES.txt
@@ -262,10 +262,9 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/okapi-logical/NOTICE.txt
+++ b/okapi-logical/NOTICE.txt
@@ -53,9 +53,8 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar

--- a/okapi-neo4j-io/LICENSES.txt
+++ b/okapi-neo4j-io/LICENSES.txt
@@ -262,10 +262,9 @@ MIT
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/okapi-neo4j-io/NOTICE.txt
+++ b/okapi-neo4j-io/NOTICE.txt
@@ -53,9 +53,8 @@ MIT
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar

--- a/okapi-relational/LICENSES.txt
+++ b/okapi-relational/LICENSES.txt
@@ -262,10 +262,9 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/okapi-relational/NOTICE.txt
+++ b/okapi-relational/NOTICE.txt
@@ -53,9 +53,8 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar

--- a/spark-cypher/LICENSES.txt
+++ b/spark-cypher/LICENSES.txt
@@ -263,10 +263,9 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar
 ------------------------------------------------------------------------------

--- a/spark-cypher/NOTICE.txt
+++ b/spark-cypher/NOTICE.txt
@@ -54,9 +54,8 @@ MIT
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   eff_2.11-5.0.0.jar
-  fastparse-utils_2.11-1.0.0.jar
-  fastparse_2.11-1.0.0.jar
+  fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
-  sourcecode_2.11-0.1.4.jar
+  sourcecode_2.11-0.1.5.jar
   ujson_2.11-0.6.6.jar
   upickle_2.11-0.6.6.jar


### PR DESCRIPTION
[FastParse 2.1.0 should be 3-4x faster](https://www.lihaoyi.com/fastparse) and allows us to stay up-to-date cheaply going forward.