### PR TITLE
Improve SQL PGDS data source configs

### DIFF
--- a/build.licenses.gradle
+++ b/build.licenses.gradle
@@ -120,6 +120,8 @@ subprojects {
         }
     }
 
+    tasks.downloadLicenses.outputs.upToDateWhen { false }
+
     tasks.downloadLicenses.ext.licencesJson = { ->
         def jsonDir = tasks.downloadLicenses.jsonDestination
         def jsonFile = file("$jsonDir/license-dependency.json")

--- a/build.params.gradle
+++ b/build.params.gradle
@@ -21,7 +21,7 @@ ext {
             spark       : '2.2.3',
             hadoop      : '2.7.0',
             fastparse   : '2.1.0',
-            upickle     : '0.6.6',
+            upickle     : '0.7.1',
             cats        : '1.0.1',
             eff         : '5.0.0',
             bctls       : '1.59',

--- a/graph-ddl/LICENSES.txt
+++ b/graph-ddl/LICENSES.txt
@@ -258,14 +258,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/graph-ddl/NOTICE.txt
+++ b/graph-ddl/NOTICE.txt
@@ -49,11 +49,15 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/okapi-api/LICENSES.txt
+++ b/okapi-api/LICENSES.txt
@@ -258,14 +258,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/okapi-api/NOTICE.txt
+++ b/okapi-api/NOTICE.txt
@@ -49,11 +49,15 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/okapi-api/build.gradle
+++ b/okapi-api/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     }
 
     compile group: 'org.typelevel',  name: "cats-core".scala(), version: ver.cats
-    compile group: 'com.lihaoyi',    name: "upickle".scala(),   version: ver.upickle
+    compile(group: 'com.lihaoyi',    name: "upickle".scala(),   version: ver.upickle) {
+        exclude group: 'com.lihaoyi', module: 'utest_2.11'
+    }
     compile group: 'com.lihaoyi',    name: "fastparse".scala(), version: ver.fastparse
 
     testCompile group: 'org.mockito', name: 'mockito-all', version: ver.mockito

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/util/ZeppelinSupport.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/util/ZeppelinSupport.scala
@@ -32,7 +32,7 @@ import org.opencypher.okapi.api.value.CypherValue.CypherEntity._
 import org.opencypher.okapi.api.value.CypherValue.CypherNode._
 import org.opencypher.okapi.api.value.CypherValue.CypherRelationship._
 import org.opencypher.okapi.api.value.CypherValue.{CypherNode, CypherRelationship}
-import upickle.Js
+import ujson._
 
 import scala.util.Random
 
@@ -205,11 +205,11 @@ object ZeppelinSupport {
       * }
       * }}}
       */
-    def toZeppelinJson: Js.Value = {
+    def toZeppelinJson: Value = {
       val default = n.toJson
-      Js.Obj(
+      Obj(
         idJsonKey -> default(idJsonKey),
-        labelJsonKey -> Js.Str(n.labels.headOption.getOrElse("")),
+        labelJsonKey -> Str(n.labels.headOption.getOrElse("")),
         labelsJsonKey -> default(labelsJsonKey),
         dataJsonKey -> default(propertiesJsonKey)
       )
@@ -234,9 +234,9 @@ object ZeppelinSupport {
       * }
       * }}}
       */
-    def toZeppelinJson: Js.Value = {
+    def toZeppelinJson: Value = {
       val default = r.toJson
-      Js.Obj(
+      Obj(
         idJsonKey -> default(idJsonKey),
         sourceJsonKey -> default(startIdJsonKey),
         targetJsonKey -> default(endIdJsonKey),
@@ -260,16 +260,16 @@ object ZeppelinSupport {
       * }
       * }}}
       */
-    def toZeppelinJson(nodes: Iterator[CypherNode[_]], rels: Iterator[CypherRelationship[_]], labels: Set[String], types: Set[String]): Js.Value = {
+    def toZeppelinJson(nodes: Iterator[CypherNode[_]], rels: Iterator[CypherRelationship[_]], labels: Set[String], types: Set[String]): Value = {
       val nodeJsons = nodes.map(_.toZeppelinJson)
       val relJson = rels.map(_.toZeppelinJson)
 
-      Js.Obj(
+      Obj(
         "nodes" -> nodeJsons,
         "edges" -> relJson,
-        "labels" -> labels.toSeq.sorted.map(l => l -> Js.Str(colorForLabel(l))),
-        "types" -> types.toSeq.sorted.map(Js.Str),
-        "directed" -> Js.True
+        "labels" -> labels.toSeq.sorted.map(l => l -> Str(colorForLabel(l))),
+        "types" -> types.toSeq.sorted.map(Str),
+        "directed" -> True
       )
     }
 
@@ -357,7 +357,7 @@ object ZeppelinSupport {
       * }
       * }}}
       */
-    def toZeppelinJson: Js.Value = {
+    def toZeppelinJson: Value = {
       val nodes = g.nodes("n").iterator.map(m => m("n").cast[CypherNode[_]])
       val rels = g.relationships("r").iterator.map(m => m("r").cast[CypherRelationship[_]])
 

--- a/okapi-api/src/main/scala/org/opencypher/okapi/api/value/CypherValue.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/api/value/CypherValue.scala
@@ -26,14 +26,13 @@
  */
 package org.opencypher.okapi.api.value
 
-import java.sql.Date
 import java.util.Objects
 
 import org.opencypher.okapi.api.value.CypherValue.CypherEntity._
 import org.opencypher.okapi.api.value.CypherValue.CypherNode._
 import org.opencypher.okapi.api.value.CypherValue.CypherRelationship._
 import org.opencypher.okapi.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
-import upickle.Js
+import ujson._
 
 import scala.reflect.{ClassTag, classTag}
 import scala.util.Try
@@ -199,30 +198,30 @@ object CypherValue {
       }
     }
 
-    def toJson: Js.Value = {
+    def toJson: Value = {
       this match {
-        case CypherNull => Js.Null
-        case CypherString(s) => Js.Str(s)
+        case CypherNull => Null
+        case CypherString(s) => Str(s)
         case CypherList(l) => l.map(_.toJson)
         case CypherMap(m) => m.mapValues(_.toJson).toSeq.sortBy(_._1)
         case CypherRelationship(id, startId, endId, relType, properties) =>
-          Js.Obj(
-            idJsonKey -> Js.Str(id.toString),
-            typeJsonKey -> Js.Str(relType),
-            startIdJsonKey -> Js.Str(startId.toString),
-            endIdJsonKey -> Js.Str(endId.toString),
+          Obj(
+            idJsonKey -> Str(id.toString),
+            typeJsonKey -> Str(relType),
+            startIdJsonKey -> Str(startId.toString),
+            endIdJsonKey -> Str(endId.toString),
             propertiesJsonKey -> properties.toJson
           )
         case CypherNode(id, labels, properties) =>
-          Js.Obj(
-            idJsonKey -> Js.Str(id.toString),
-            labelsJsonKey -> labels.toSeq.sorted.map(Js.Str),
+          Obj(
+            idJsonKey -> Str(id.toString),
+            labelsJsonKey -> labels.toSeq.sorted.map(Str),
             propertiesJsonKey -> properties.toJson
           )
-        case CypherFloat(d) => Js.Num(d)
-        case CypherInteger(l) => Js.Str(l.toString) // `Js.Num` would lose precision
-        case CypherBoolean(b) => Js.Bool(b)
-        case other => Js.Str(other.value.toString)
+        case CypherFloat(d) => Num(d)
+        case CypherInteger(l) => Str(l.toString) // `Num` would lose precision
+        case CypherBoolean(b) => Bool(b)
+        case other => Str(other.value.toString)
       }
     }
 

--- a/okapi-ir/LICENSES.txt
+++ b/okapi-ir/LICENSES.txt
@@ -258,6 +258,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -265,8 +266,11 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/okapi-ir/NOTICE.txt
+++ b/okapi-ir/NOTICE.txt
@@ -49,6 +49,7 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -56,5 +57,8 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/okapi-logical/LICENSES.txt
+++ b/okapi-logical/LICENSES.txt
@@ -258,6 +258,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -265,8 +266,11 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/okapi-logical/NOTICE.txt
+++ b/okapi-logical/NOTICE.txt
@@ -49,6 +49,7 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -56,5 +57,8 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/okapi-neo4j-io/LICENSES.txt
+++ b/okapi-neo4j-io/LICENSES.txt
@@ -259,14 +259,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/okapi-neo4j-io/NOTICE.txt
+++ b/okapi-neo4j-io/NOTICE.txt
@@ -50,11 +50,15 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/okapi-relational/LICENSES.txt
+++ b/okapi-relational/LICENSES.txt
@@ -258,6 +258,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -265,8 +266,11 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/okapi-relational/NOTICE.txt
+++ b/okapi-relational/NOTICE.txt
@@ -49,6 +49,7 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -56,5 +57,8 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/spark-cypher-examples/src/main/resources/census/ddl/hive-data-sources.json
+++ b/spark-cypher-examples/src/main/resources/census/ddl/hive-data-sources.json
@@ -1,6 +1,0 @@
-[
-  {
-    "storageFormat": "hive",
-    "dataSourceName": "CENSUS"
-  }
-]

--- a/spark-cypher-examples/src/main/resources/census/ddl/jdbc-data-sources.json
+++ b/spark-cypher-examples/src/main/resources/census/ddl/jdbc-data-sources.json
@@ -1,9 +1,0 @@
-[
-  {
-    "storageFormat": "jdbc",
-    "dataSourceName": "CENSUS",
-    "jdbcUri": "jdbc:h2:mem:CENSUS.db;INIT=CREATE SCHEMA IF NOT EXISTS CENSUS;DB_CLOSE_DELAY=30;",
-    "jdbcDriver": "org.h2.Driver",
-    "jdbcFetchSize": 100
-  }
-]

--- a/spark-cypher-examples/src/main/resources/customer-interactions/ddl/data-sources.json
+++ b/spark-cypher-examples/src/main/resources/customer-interactions/ddl/data-sources.json
@@ -1,6 +1,0 @@
-[
-  {
-    "storageFormat": "hive",
-    "dataSourceName": "hive"
-  }
-]

--- a/spark-cypher-examples/src/main/resources/ldbc/ddl/data-sources.json
+++ b/spark-cypher-examples/src/main/resources/ldbc/ddl/data-sources.json
@@ -1,6 +1,0 @@
-[
-  {
-    "storageFormat": "hive",
-    "dataSourceName": "warehouse"
-  }
-]

--- a/spark-cypher-examples/src/main/resources/northwind/ddl/jdbc-data-sources.json
+++ b/spark-cypher-examples/src/main/resources/northwind/ddl/jdbc-data-sources.json
@@ -1,9 +1,0 @@
-[
-  {
-    "storageFormat": "jdbc",
-    "dataSourceName": "H2",
-    "jdbcUri": "jdbc:h2:mem:NORTHWIND.db;INIT=CREATE SCHEMA IF NOT EXISTS NORTHWIND;DB_CLOSE_DELAY=30;",
-    "jdbcDriver":"org.h2.Driver",
-    "jdbcFetchSize": 100
-  }
-]

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CensusHiveExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CensusHiveExample.scala
@@ -52,11 +52,11 @@ object CensusHiveExample extends ConsoleApp {
   val graphName = "Census_1901"
   val sqlGraphSource = GraphSources
       .sql(resource("ddl/census.ddl").getFile)
-      .withSqlDataSourceConfigs("CENSUS" -> Hive())
+      .withSqlDataSourceConfigs("CENSUS" -> Hive)
 
   // tag::prepare-sql-database[]
   // Create the data in H2 in-memory database
-  CensusDB.createHiveData(Hive())
+  CensusDB.createHiveData(Hive)
   // end::prepare-sql-database[]
 
   session.registerSource(Namespace("sql"), sqlGraphSource)

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CensusHiveExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CensusHiveExample.scala
@@ -32,6 +32,7 @@ import java.io.File
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.opencypher.okapi.api.graph.Namespace
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.Hive
 import org.opencypher.spark.api.{CAPSSession, GraphSources}
 import org.opencypher.spark.util.{CensusDB, ConsoleApp}
 
@@ -51,11 +52,11 @@ object CensusHiveExample extends ConsoleApp {
   val graphName = "Census_1901"
   val sqlGraphSource = GraphSources
       .sql(resource("ddl/census.ddl").getFile)
-      .withSqlDataSourceConfigs(resource("ddl/hive-data-sources.json").getFile)
+      .withSqlDataSourceConfigs("CENSUS" -> Hive())
 
   // tag::prepare-sql-database[]
   // Create the data in H2 in-memory database
-  CensusDB.createHiveData(sqlGraphSource.sqlDataSourceConfigs.find(_.dataSourceName == "CENSUS").get)
+  CensusDB.createHiveData(Hive())
   // end::prepare-sql-database[]
 
   session.registerSource(Namespace("sql"), sqlGraphSource)

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CensusJdbcExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/CensusJdbcExample.scala
@@ -29,6 +29,7 @@ package org.opencypher.spark.examples
 
 import org.apache.spark.sql.SparkSession
 import org.opencypher.okapi.api.graph.Namespace
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig
 import org.opencypher.spark.api.{CAPSSession, GraphSources}
 import org.opencypher.spark.util.{CensusDB, ConsoleApp}
 
@@ -42,12 +43,16 @@ object CensusJdbcExample extends ConsoleApp {
 
   // Register a SQL source (for JDBC) in the Cypher session
   val graphName = "Census_1901"
+  val dataSourceConfig = SqlDataSourceConfig.Jdbc(
+    url = "jdbc:h2:mem:CENSUS.db;INIT=CREATE SCHEMA IF NOT EXISTS CENSUS;DB_CLOSE_DELAY=30;",
+    driver = "org.h2.Driver"
+  )
   val sqlGraphSource = GraphSources
     .sql(resource("ddl/census.ddl").getFile)
-    .withSqlDataSourceConfigs(resource("ddl/jdbc-data-sources.json").getFile)
+    .withSqlDataSourceConfigs("CENSUS" -> dataSourceConfig)
 
   // Create the data in H2 in-memory database
-  CensusDB.createJdbcData(sqlGraphSource.sqlDataSourceConfigs.find(_.dataSourceName == "CENSUS").get)
+  CensusDB.createJdbcData(dataSourceConfig)
 
   session.registerSource(Namespace("sql"), sqlGraphSource)
 

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/LdbcHiveExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/LdbcHiveExample.scala
@@ -32,6 +32,7 @@ import java.nio.file.Files
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.opencypher.okapi.api.graph.Namespace
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.Hive
 import org.opencypher.spark.api.{CAPSSession, GraphSources}
 import org.opencypher.spark.testing.utils.FileSystemUtils._
 import org.opencypher.spark.util.LdbcUtil._
@@ -50,7 +51,7 @@ import org.opencypher.spark.util.{ConsoleApp, LdbcUtil}
 object LdbcHiveExample extends ConsoleApp {
 
   implicit val resourceFolder: String = "/ldbc"
-  val datasource = "warehouse"
+  val datasourceName = "warehouse"
   val database = "LDBC"
 
   implicit val session: CAPSSession = CAPSSession.local(CATALOG_IMPLEMENTATION.key -> "hive")
@@ -80,14 +81,14 @@ object LdbcHiveExample extends ConsoleApp {
   views.foreach(spark.sql)
 
   // generate GraphDdl file
-  val graphDdlString = LdbcUtil.toGraphDDL(datasource, database)
+  val graphDdlString = LdbcUtil.toGraphDDL(datasourceName, database)
   val graphDdlFile = Files.createTempFile("ldbc", ".ddl").toFile.getAbsolutePath
   writeFile(graphDdlFile, graphDdlString)
 
   // create SQL PGDS
   val sqlGraphSource = GraphSources
     .sql(graphDdlFile)
-    .withSqlDataSourceConfigs(resource("ddl/data-sources.json").getFile)
+    .withSqlDataSourceConfigs(datasourceName -> Hive())
 
   session.registerSource(Namespace("sql"), sqlGraphSource)
 

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/LdbcHiveExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/LdbcHiveExample.scala
@@ -88,7 +88,7 @@ object LdbcHiveExample extends ConsoleApp {
   // create SQL PGDS
   val sqlGraphSource = GraphSources
     .sql(graphDdlFile)
-    .withSqlDataSourceConfigs(datasourceName -> Hive())
+    .withSqlDataSourceConfigs(datasourceName -> Hive)
 
   session.registerSource(Namespace("sql"), sqlGraphSource)
 

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/NorthwindJdbcExample.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/NorthwindJdbcExample.scala
@@ -28,6 +28,7 @@
 package org.opencypher.spark.examples
 
 import org.opencypher.okapi.api.graph.Namespace
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig
 import org.opencypher.spark.api.{CAPSSession, GraphSources}
 import org.opencypher.spark.util.{ConsoleApp, NorthwindDB}
 
@@ -42,12 +43,16 @@ object NorthwindJdbcExample extends ConsoleApp {
   // this holds the data source mappings files and the SQL DDL file
   // the latter contains the graph definitions and mappings from SQL tables that fill the graph with data
 
+  val dataSourceConfig = SqlDataSourceConfig.Jdbc(
+    url = "jdbc:h2:mem:NORTHWIND.db;INIT=CREATE SCHEMA IF NOT EXISTS NORTHWIND;DB_CLOSE_DELAY=30;",
+    driver = "org.h2.Driver"
+  )
   val sqlGraphSource = GraphSources
     .sql(resource("ddl/northwind.ddl").getFile)
-    .withSqlDataSourceConfigs(resource("ddl/jdbc-data-sources.json").getFile)
+    .withSqlDataSourceConfigs("H2" -> dataSourceConfig)
 
   // start up the SQL database
-  NorthwindDB.init(sqlGraphSource.sqlDataSourceConfigs.find(_.dataSourceName == "H2").get)
+  NorthwindDB.init(dataSourceConfig)
 
   // register the SQL graph source with the session
   session.registerSource(Namespace("sql"), sqlGraphSource)

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/util/CensusDB.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/util/CensusDB.scala
@@ -28,9 +28,9 @@ package org.opencypher.spark.util
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
+import org.opencypher.spark.api.io.{FileFormat, StorageFormat}
 import org.opencypher.spark.api.io.sql.SqlDataSourceConfig
 import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.Jdbc
-import org.opencypher.spark.api.io.{ParquetFormat, StorageFormat}
 import org.opencypher.spark.testing.utils.H2Utils._
 
 import scala.io.Source
@@ -129,10 +129,10 @@ object CensusDB {
     sparkSession.sql(s"CREATE DATABASE CENSUS").count
 
     // Populate the data
-    populateData(townInput, sqlDataSourceConfig, Some(ParquetFormat))
-    populateData(residentsInput, sqlDataSourceConfig, Some(ParquetFormat))
-    populateData(visitorsInput, sqlDataSourceConfig, Some(ParquetFormat))
-    populateData(licensedDogsInput, sqlDataSourceConfig, Some(ParquetFormat))
+    populateData(townInput, sqlDataSourceConfig, Some(FileFormat.parquet))
+    populateData(residentsInput, sqlDataSourceConfig, Some(FileFormat.parquet))
+    populateData(visitorsInput, sqlDataSourceConfig, Some(FileFormat.parquet))
+    populateData(licensedDogsInput, sqlDataSourceConfig, Some(FileFormat.parquet))
 
     // Create the views
     createViewsSql.split(";").foreach(sparkSession.sql)

--- a/spark-cypher-examples/src/main/scala/org/opencypher/spark/util/NorthwindDB.scala
+++ b/spark-cypher-examples/src/main/scala/org/opencypher/spark/util/NorthwindDB.scala
@@ -34,7 +34,7 @@ import scala.util.Properties
 
 object NorthwindDB {
 
-  def init(sqlDataSourceConfig: SqlDataSourceConfig): Unit = {
+  def init(sqlDataSourceConfig: SqlDataSourceConfig.Jdbc): Unit = {
 
     withConnection(sqlDataSourceConfig) { connection =>
 

--- a/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/fixture/H2Fixture.scala
+++ b/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/fixture/H2Fixture.scala
@@ -34,15 +34,15 @@ import org.opencypher.spark.testing.utils.H2Utils._
 trait H2Fixture extends SparkSessionFixture {
   self: BaseTestSuite =>
 
-  def createH2Database(cfg: SqlDataSourceConfig, name: String): Unit = {
+  def createH2Database(cfg: SqlDataSourceConfig.Jdbc, name: String): Unit = {
     withConnection(cfg) { conn => conn.execute(s"CREATE SCHEMA IF NOT EXISTS $name")}
   }
 
-  def dropH2Database(cfg: SqlDataSourceConfig, name: String): Unit = {
+  def dropH2Database(cfg: SqlDataSourceConfig.Jdbc, name: String): Unit = {
     withConnection(cfg) { conn => conn.execute(s"DROP SCHEMA IF EXISTS $name")}
   }
 
-  def freshH2Database(cfg: SqlDataSourceConfig, name: String): Unit = {
+  def freshH2Database(cfg: SqlDataSourceConfig.Jdbc, name: String): Unit = {
     dropH2Database(cfg, name)
     createH2Database(cfg, name)
   }

--- a/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/utils/H2Utils.scala
+++ b/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/utils/H2Utils.scala
@@ -54,7 +54,7 @@ object H2Utils {
     try { code(conn) } finally { conn.close() }
   }
 
-  implicit class DataFrameReaderOps(write: DataFrameWriter[Row]) {
+  implicit class DataFrameWriterOps(write: DataFrameWriter[Row]) {
     def maybeOption(key: String, value: Option[String]): DataFrameWriter[Row] =
       value.fold(write)(write.option(key, _))
   }

--- a/spark-cypher-testing/src/test/resources/sql/sql-data-sources.json
+++ b/spark-cypher-testing/src/test/resources/sql/sql-data-sources.json
@@ -1,30 +1,31 @@
-[
-  {
-    "storageFormat": "jdbc",
-    "dataSourceName": "CENSUS_ORACLE",
-    "schemaName": "CENSUS",
-    "jdbcUri": "jdbc:h2:mem:CENSUS.db;INIT=CREATE SCHEMA IF NOT EXISTS CENSUS;DB_CLOSE_DELAY=30;",
-    "jdbcDriver": "org.h2.Driver",
-    "jdbcFetchSize": 100
+{
+  "CENSUS_ORACLE": {
+    "type": "jdbc",
+    "url": "jdbc:h2:mem:CENSUS.db;INIT=CREATE SCHEMA IF NOT EXISTS CENSUS;DB_CLOSE_DELAY=30;",
+    "driver": "org.h2.Driver",
+    "options": {
+      "fetchSize": "100"
+    }
   },
-  {
-    "storageFormat": "jdbc",
-    "dataSourceName": "ORACLE_X2",
-    "schemaName": "X2",
-    "jdbcUri": "jdbc:h2:mem:X2.db;INIT=CREATE SCHEMA IF NOT EXISTS X2;DB_CLOSE_DELAY=30;",
-    "jdbcDriver": "org.h2.Driver",
-    "jdbcUser": "ORACLE_X2_USER",
-    "jdbcPassword": "ORACLE_X2_PASS",
-    "jdbcFetchSize": 10
+  "ORACLE_X2": {
+    "type": "jdbc",
+    "url": "jdbc:h2:mem:X2.db;INIT=CREATE SCHEMA IF NOT EXISTS X2;DB_CLOSE_DELAY=30;",
+    "driver": "org.h2.Driver",
+    "options": {
+      "user": "ORACLE_X2_USER",
+      "password": "ORACLE_X2_PASS",
+      "fetchSize": "10"
+    }
   },
-  {
-    "storageFormat": "hive",
-    "dataSourceName": "HIVE_CENSUS",
-    "schemaName": "CENSUS"
+  "HIVE_CENSUS": {
+    "type": "hive"
   },
-  {
-    "storageFormat": "hive",
-    "dataSourceName": "HIVE_X2",
-    "schemaName": "X2"
+  "HIVE_X2": {
+    "type": "hive"
+  },
+  "MY_DIR": {
+    "type": "file",
+    "format": "parquet",
+    "basePath": "/my/path"
   }
-]
+}

--- a/spark-cypher-testing/src/test/resources/sql/sql-data-sources.json
+++ b/spark-cypher-testing/src/test/resources/sql/sql-data-sources.json
@@ -13,6 +13,8 @@
     "schemaName": "X2",
     "jdbcUri": "jdbc:h2:mem:X2.db;INIT=CREATE SCHEMA IF NOT EXISTS X2;DB_CLOSE_DELAY=30;",
     "jdbcDriver": "org.h2.Driver",
+    "jdbcUser": "ORACLE_X2_USER",
+    "jdbcPassword": "ORACLE_X2_PASS",
     "jdbcFetchSize": 10
   },
   {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/csv/MultipleFilesPerTableDataSourceAcceptance.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/csv/MultipleFilesPerTableDataSourceAcceptance.scala
@@ -27,7 +27,7 @@
 package org.opencypher.spark.api.io.csv
 
 import org.opencypher.okapi.relational.api.graph.RelationalCypherGraph
-import org.opencypher.spark.api.io.CsvFormat
+import org.opencypher.spark.api.io.FileFormat
 import org.opencypher.spark.api.io.fs.FSGraphSource
 import org.opencypher.spark.api.io.fs.hdfs.HdfsDataSourceAcceptance
 import org.opencypher.spark.impl.io.CAPSPropertyGraphDataSource
@@ -36,7 +36,7 @@ import org.opencypher.spark.impl.table.SparkTable.DataFrameTable
 class MultipleFilesPerTableDataSourceAcceptance extends HdfsDataSourceAcceptance {
 
   override protected def createDs(graph: RelationalCypherGraph[DataFrameTable]): CAPSPropertyGraphDataSource = {
-    new FSGraphSource(hdfsURI.toString, CsvFormat, filesPerTable = Some(10))
+    new FSGraphSource(hdfsURI.toString, FileFormat.csv, filesPerTable = Some(10))
   }
 
 }

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/fs/FSGraphSourceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/fs/FSGraphSourceTest.scala
@@ -32,7 +32,7 @@ import org.opencypher.okapi.api.graph.{GraphName, Node, Relationship}
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.api.GraphSources
-import org.opencypher.spark.api.io.ParquetFormat
+import org.opencypher.spark.api.io.FileFormat
 import org.opencypher.spark.api.io.util.HiveTableName
 import org.opencypher.spark.api.value.CAPSNode
 import org.opencypher.spark.impl.acceptance.ScanGraphInit
@@ -67,7 +67,8 @@ class FSGraphSourceTest extends CAPSTestSuite with ScanGraphInit {
     it("writes nodes and relationships to hive tables") {
       val given = testGraph
 
-      val fs = new FSGraphSource("file:///" + tempDir.getRoot.getAbsolutePath.replace("\\", "/"), ParquetFormat, Some(testDatabaseName), None)
+      val fs = new FSGraphSource("file:///" + tempDir.getRoot.getAbsolutePath.replace("\\", "/"),
+        FileFormat.parquet, Some(testDatabaseName), None)
       fs.store(graphName, given)
 
       val nodeResult = caps.sparkSession.sql(s"SELECT * FROM $nodeTableName")
@@ -89,7 +90,8 @@ class FSGraphSourceTest extends CAPSTestSuite with ScanGraphInit {
     it("deletes the hive database if the graph is deleted") {
       val given = testGraph
 
-      val fs = new FSGraphSource("file:///" + tempDir.getRoot.getAbsolutePath.replace("\\", "/"), ParquetFormat, Some(testDatabaseName), None)
+      val fs = new FSGraphSource("file:///" + tempDir.getRoot.getAbsolutePath.replace("\\", "/"),
+        FileFormat.parquet, Some(testDatabaseName), None)
       fs.store(graphName, given)
 
       caps.sparkSession.sql(s"SELECT * FROM $nodeTableName").collect().toSet should not be empty

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/neo4j/sync/Neo4JGraphMergeTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/neo4j/sync/Neo4JGraphMergeTest.scala
@@ -211,7 +211,7 @@ class Neo4JGraphMergeTest extends CAPSTestSuite with Neo4jServerFixture with Sca
           |  (Person) FROM ds1.db.persons
           |)
         """.stripMargin
-      val hiveDataSourceConfig = SqlDataSourceConfig.Hive()
+      val hiveDataSourceConfig = SqlDataSourceConfig.Hive
       val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("ds1" -> hiveDataSourceConfig))
       val graph = pgds.graph(GraphName("personGraph"))
 

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/neo4j/sync/Neo4JGraphMergeTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/neo4j/sync/Neo4JGraphMergeTest.scala
@@ -211,12 +211,8 @@ class Neo4JGraphMergeTest extends CAPSTestSuite with Neo4jServerFixture with Sca
           |  (Person) FROM ds1.db.persons
           |)
         """.stripMargin
-      val hiveDataSourceConfig = SqlDataSourceConfig(
-        storageFormat = HiveFormat,
-        dataSourceName = "ds1"
-      )
-
-      val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(hiveDataSourceConfig))
+      val hiveDataSourceConfig = SqlDataSourceConfig.Hive()
+      val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("ds1" -> hiveDataSourceConfig))
       val graph = pgds.graph(GraphName("personGraph"))
 
       Neo4jGraphMerge.createIndexes(entireGraphName, neo4jConfig, graph.schema.nodeKeys)

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/FileSqlPGDSAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/FileSqlPGDSAcceptanceTest.scala
@@ -29,11 +29,11 @@ package org.opencypher.spark.api.io.sql
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.junit.rules.TemporaryFolder
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy.{IdGenerationStrategy, _}
-import org.opencypher.spark.api.io.{CsvFormat, OrcFormat, ParquetFormat, StorageFormat}
+import org.opencypher.spark.api.io._
 
 abstract class FileSqlPGDSAcceptanceTest extends SqlPropertyGraphDataSourceAcceptanceTest {
 
-  def format: StorageFormat
+  def format: TabularFileFormat
 
   var tempDir: TemporaryFolder = new TemporaryFolder()
   lazy val basePath: String =  "file:///" + tempDir.getRoot.getAbsolutePath.replace("\\", "/")
@@ -49,7 +49,7 @@ abstract class FileSqlPGDSAcceptanceTest extends SqlPropertyGraphDataSourceAccep
   }
 
   override def sqlDataSourceConfig: SqlDataSourceConfig =
-    SqlDataSourceConfig(format, dataSourceName, basePath = Some(basePath))
+    SqlDataSourceConfig.File(format, Some(basePath))
 
   override def writeTable(df: DataFrame, tableName: String): Unit = {
     val path = basePath + s"/${tableName.replace(s"$databaseName.","")}"
@@ -58,32 +58,32 @@ abstract class FileSqlPGDSAcceptanceTest extends SqlPropertyGraphDataSourceAccep
 }
 
 class ParquetSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends FileSqlPGDSAcceptanceTest {
-  override def format: StorageFormat = ParquetFormat
+  override def format: TabularFileFormat = ParquetFormat
   override val idGenerationStrategy: IdGenerationStrategy = MonotonicallyIncreasingId
 }
 
 class ParquetSqlPGDSAcceptanceHashBasedTest extends FileSqlPGDSAcceptanceTest {
-  override def format: StorageFormat = ParquetFormat
+  override def format: TabularFileFormat = ParquetFormat
   override val idGenerationStrategy: IdGenerationStrategy = HashBasedId
 }
 
 class CsvSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends FileSqlPGDSAcceptanceTest {
-  override def format: StorageFormat = CsvFormat
+  override def format: TabularFileFormat = CsvFormat
   override val idGenerationStrategy: IdGenerationStrategy = MonotonicallyIncreasingId
 }
 
 class CsvSqlPGDSAcceptanceHashBasedTest extends FileSqlPGDSAcceptanceTest {
-  override def format: StorageFormat = CsvFormat
+  override def format: TabularFileFormat = CsvFormat
   override val idGenerationStrategy: IdGenerationStrategy = HashBasedId
 }
 
 
 class OrcSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends FileSqlPGDSAcceptanceTest {
-  override def format: StorageFormat = OrcFormat
+  override def format: TabularFileFormat = OrcFormat
   override val idGenerationStrategy: IdGenerationStrategy = MonotonicallyIncreasingId
 }
 
 class OrcSqlPGDSAcceptanceHashBasedTest extends FileSqlPGDSAcceptanceTest {
-  override def format: StorageFormat = OrcFormat
+  override def format: TabularFileFormat = OrcFormat
   override val idGenerationStrategy: IdGenerationStrategy = HashBasedId
 }

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/FileSqlPGDSAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/FileSqlPGDSAcceptanceTest.scala
@@ -28,12 +28,12 @@ package org.opencypher.spark.api.io.sql
 
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.junit.rules.TemporaryFolder
-import org.opencypher.spark.api.io.sql.IdGenerationStrategy.{IdGenerationStrategy, _}
 import org.opencypher.spark.api.io._
+import org.opencypher.spark.api.io.sql.IdGenerationStrategy.{IdGenerationStrategy, _}
 
 abstract class FileSqlPGDSAcceptanceTest extends SqlPropertyGraphDataSourceAcceptanceTest {
 
-  def format: TabularFileFormat
+  def format: FileFormat
 
   var tempDir: TemporaryFolder = new TemporaryFolder()
   lazy val basePath: String =  "file:///" + tempDir.getRoot.getAbsolutePath.replace("\\", "/")
@@ -58,32 +58,32 @@ abstract class FileSqlPGDSAcceptanceTest extends SqlPropertyGraphDataSourceAccep
 }
 
 class ParquetSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends FileSqlPGDSAcceptanceTest {
-  override def format: TabularFileFormat = ParquetFormat
+  override def format: FileFormat = FileFormat.parquet
   override val idGenerationStrategy: IdGenerationStrategy = MonotonicallyIncreasingId
 }
 
 class ParquetSqlPGDSAcceptanceHashBasedTest extends FileSqlPGDSAcceptanceTest {
-  override def format: TabularFileFormat = ParquetFormat
+  override def format: FileFormat = FileFormat.parquet
   override val idGenerationStrategy: IdGenerationStrategy = HashBasedId
 }
 
 class CsvSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends FileSqlPGDSAcceptanceTest {
-  override def format: TabularFileFormat = CsvFormat
+  override def format: FileFormat = FileFormat.csv
   override val idGenerationStrategy: IdGenerationStrategy = MonotonicallyIncreasingId
 }
 
 class CsvSqlPGDSAcceptanceHashBasedTest extends FileSqlPGDSAcceptanceTest {
-  override def format: TabularFileFormat = CsvFormat
+  override def format: FileFormat = FileFormat.csv
   override val idGenerationStrategy: IdGenerationStrategy = HashBasedId
 }
 
 
 class OrcSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends FileSqlPGDSAcceptanceTest {
-  override def format: TabularFileFormat = OrcFormat
+  override def format: FileFormat = FileFormat.orc
   override val idGenerationStrategy: IdGenerationStrategy = MonotonicallyIncreasingId
 }
 
 class OrcSqlPGDSAcceptanceHashBasedTest extends FileSqlPGDSAcceptanceTest {
-  override def format: TabularFileFormat = OrcFormat
+  override def format: FileFormat = FileFormat.orc
   override val idGenerationStrategy: IdGenerationStrategy = HashBasedId
 }

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/H2SqlPGDSHashBasedIdAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/H2SqlPGDSHashBasedIdAcceptanceTest.scala
@@ -28,7 +28,6 @@ package org.opencypher.spark.api.io.sql
 
 import org.apache.spark.sql.DataFrame
 import org.h2.jdbc.JdbcSQLException
-import org.opencypher.spark.api.io.JdbcFormat
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy.{IdGenerationStrategy, _}
 import org.opencypher.spark.testing.fixture.H2Fixture
 import org.opencypher.spark.testing.utils.H2Utils._
@@ -47,14 +46,14 @@ class H2SqlPGDSHashBasedIdAcceptanceTest extends SqlPropertyGraphDataSourceAccep
     super.afterAll()
   }
 
-  override def sqlDataSourceConfig: SqlDataSourceConfig =
-    SqlDataSourceConfig(
-      storageFormat = JdbcFormat,
-      dataSourceName = dataSourceName,
-      jdbcDriver = Some("org.h2.Driver"),
-      jdbcUri = Some("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"),
-      jdbcUser = Some("sa"),
-      jdbcPassword = Some("1234")
+  override def sqlDataSourceConfig: SqlDataSourceConfig.Jdbc =
+    SqlDataSourceConfig.Jdbc(
+      url = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",
+      driver = "org.h2.Driver",
+      options = Map(
+        "user" -> "sa",
+        "password" -> "1234"
+      )
     )
 
   override def writeTable(df: DataFrame, tableName: String): Unit =
@@ -62,7 +61,7 @@ class H2SqlPGDSHashBasedIdAcceptanceTest extends SqlPropertyGraphDataSourceAccep
 
   it("fails if an invalid user is supplied") {
     an[JdbcSQLException] shouldBe thrownBy {
-      withConnection(sqlDataSourceConfig.copy(jdbcUser = Some("foo"))) { _ => }
+      withConnection(sqlDataSourceConfig.copy(options = sqlDataSourceConfig.options.updated("user", "foo"))) { _ => }
     }
   }
 }

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/H2SqlPGDSMonotonicallyIncreasingIdAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/H2SqlPGDSMonotonicallyIncreasingIdAcceptanceTest.scala
@@ -46,12 +46,10 @@ class H2SqlPGDSMonotonicallyIncreasingIdAcceptanceTest extends SqlPropertyGraphD
     super.afterAll()
   }
 
-  override def sqlDataSourceConfig: SqlDataSourceConfig =
-    SqlDataSourceConfig(
-      storageFormat = JdbcFormat,
-      dataSourceName = dataSourceName,
-      jdbcDriver = Some("org.h2.Driver"),
-      jdbcUri = Some("jdbc:h2:mem:?user=sa&password=1234;DB_CLOSE_DELAY=-1")
+  override def sqlDataSourceConfig: SqlDataSourceConfig.Jdbc =
+    SqlDataSourceConfig.Jdbc(
+      driver = "org.h2.Driver",
+      url = "jdbc:h2:mem:?user=sa&password=1234;DB_CLOSE_DELAY=-1"
     )
 
   override def writeTable(df: DataFrame, tableName: String): Unit =

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest.scala
@@ -45,8 +45,8 @@ class HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends SqlPropertyGrap
     super.afterAll()
   }
 
-  override def sqlDataSourceConfig: SqlDataSourceConfig =
-    SqlDataSourceConfig(HiveFormat, dataSourceName)
+  override def sqlDataSourceConfig: SqlDataSourceConfig.Hive =
+    SqlDataSourceConfig.Hive()
 
   override def writeTable(df: DataFrame, tableName: String): Unit =
     df.write.mode(SaveMode.Overwrite).saveAsTable(tableName)

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest.scala
@@ -27,8 +27,8 @@
 package org.opencypher.spark.api.io.sql
 
 import org.apache.spark.sql.{DataFrame, SaveMode}
-import org.opencypher.spark.api.io.HiveFormat
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy.{IdGenerationStrategy, _}
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.Hive
 import org.opencypher.spark.testing.fixture.HiveFixture
 
 class HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends SqlPropertyGraphDataSourceAcceptanceTest with HiveFixture {
@@ -45,8 +45,7 @@ class HiveSqlPGDSAcceptanceMonotonicallyIncreasingIdTest extends SqlPropertyGrap
     super.afterAll()
   }
 
-  override def sqlDataSourceConfig: SqlDataSourceConfig.Hive =
-    SqlDataSourceConfig.Hive()
+  override def sqlDataSourceConfig: SqlDataSourceConfig.Hive.type = Hive
 
   override def writeTable(df: DataFrame, tableName: String): Unit =
     df.write.mode(SaveMode.Overwrite).saveAsTable(tableName)

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSHashBasedIdAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSHashBasedIdAcceptanceTest.scala
@@ -27,8 +27,8 @@
 package org.opencypher.spark.api.io.sql
 
 import org.apache.spark.sql.{DataFrame, SaveMode}
-import org.opencypher.spark.api.io.HiveFormat
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy._
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.Hive
 import org.opencypher.spark.testing.fixture.HiveFixture
 
 class HiveSqlPGDSHashBasedIdAcceptanceTest extends SqlPropertyGraphDataSourceAcceptanceTest with HiveFixture {
@@ -45,8 +45,7 @@ class HiveSqlPGDSHashBasedIdAcceptanceTest extends SqlPropertyGraphDataSourceAcc
     super.afterAll()
   }
 
-  override def sqlDataSourceConfig: SqlDataSourceConfig.Hive =
-    SqlDataSourceConfig.Hive()
+  override def sqlDataSourceConfig: Hive.type = Hive
 
   override def writeTable(df: DataFrame, tableName: String): Unit =
     df.write.mode(SaveMode.Overwrite).saveAsTable(tableName)

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSHashBasedIdAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/HiveSqlPGDSHashBasedIdAcceptanceTest.scala
@@ -45,8 +45,8 @@ class HiveSqlPGDSHashBasedIdAcceptanceTest extends SqlPropertyGraphDataSourceAcc
     super.afterAll()
   }
 
-  override def sqlDataSourceConfig: SqlDataSourceConfig =
-    SqlDataSourceConfig(HiveFormat, dataSourceName)
+  override def sqlDataSourceConfig: SqlDataSourceConfig.Hive =
+    SqlDataSourceConfig.Hive()
 
   override def writeTable(df: DataFrame, tableName: String): Unit =
     df.write.mode(SaveMode.Overwrite).saveAsTable(tableName)

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfigTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfigTest.scala
@@ -42,7 +42,7 @@ class SqlDataSourceConfigTest extends org.scalatest.FunSpec with Matchers {
     it("config to Json roundTrip") {
 
       List(
-        Hive(),
+        Hive,
         Jdbc("foo", "driv"),
         Jdbc("foo", "driv", Map("foo" -> "bar")),
         File(CsvFormat, None),
@@ -70,8 +70,8 @@ class SqlDataSourceConfigTest extends org.scalatest.FunSpec with Matchers {
             "fetchSize" -> "10"
           )
         ),
-        "HIVE_CENSUS" -> Hive(),
-        "HIVE_X2" -> Hive(),
+        "HIVE_CENSUS" -> Hive,
+        "HIVE_X2" -> Hive,
         "MY_DIR" -> File(
           format = ParquetFormat,
           basePath = Some("/my/path")

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfigTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfigTest.scala
@@ -36,13 +36,25 @@ class SqlDataSourceConfigTest extends org.scalatest.FunSpec with Matchers {
 
   describe("parsing") {
     it("parses to and from JSON") {
-      val ds = SqlDataSourceConfig(JdbcFormat, "dataSource", Some("schema"), Some("jdbcUri"), Some("jdbcDriver"), 42)
+      val ds = SqlDataSourceConfig(
+        storageFormat = JdbcFormat,
+        dataSourceName = "dataSource",
+        defaultSchema = Some("schema"),
+        jdbcUri = Some("jdbcUri"),
+        jdbcDriver = Some("jdbcDriver"),
+        jdbcUser = None,
+        jdbcPassword = None,
+        jdbcFetchSize = 42
+      )
       val jsonString = ds.toJson
       fromJson(jsonString) shouldEqual ds
     }
 
     it("parses to and from JSON with missing values") {
-      val ds = SqlDataSourceConfig(HiveFormat, "dataSource")
+      val ds = SqlDataSourceConfig(
+        storageFormat = HiveFormat,
+        dataSourceName = "dataSource"
+      )
       val jsonString = ds.toJson
       fromJson(jsonString) shouldEqual ds
     }
@@ -50,10 +62,31 @@ class SqlDataSourceConfigTest extends org.scalatest.FunSpec with Matchers {
     it("parses multiple SQL data sources") {
       val jsonString = Source.fromURL(getClass.getResource("/sql/sql-data-sources.json")).getLines().mkString("\n")
       SqlDataSourceConfig.dataSourcesFromString(jsonString) shouldEqual Map(
-        ("CENSUS_ORACLE", SqlDataSourceConfig(JdbcFormat, "CENSUS_ORACLE", None, Some("jdbc:h2:mem:CENSUS.db;INIT=CREATE SCHEMA IF NOT EXISTS CENSUS;DB_CLOSE_DELAY=30;"), Some("org.h2.Driver"), 100)),
-        ("ORACLE_X2", SqlDataSourceConfig(JdbcFormat, "ORACLE_X2", None, Some("jdbc:h2:mem:X2.db;INIT=CREATE SCHEMA IF NOT EXISTS X2;DB_CLOSE_DELAY=30;"), Some("org.h2.Driver"), 10)),
-        ("HIVE_CENSUS", SqlDataSourceConfig(HiveFormat, "HIVE_CENSUS", None, None, None, 100)),
-        ("HIVE_X2", SqlDataSourceConfig(HiveFormat, "HIVE_X2", None, None, None, 100))
+        "CENSUS_ORACLE" -> SqlDataSourceConfig(
+          storageFormat = JdbcFormat,
+          dataSourceName = "CENSUS_ORACLE",
+          defaultSchema = None,
+          jdbcUri = Some("jdbc:h2:mem:CENSUS.db;INIT=CREATE SCHEMA IF NOT EXISTS CENSUS;DB_CLOSE_DELAY=30;"),
+          jdbcDriver = Some("org.h2.Driver")
+        ),
+        "ORACLE_X2" -> SqlDataSourceConfig(
+          storageFormat = JdbcFormat,
+          dataSourceName = "ORACLE_X2",
+          defaultSchema = None,
+          jdbcUri = Some("jdbc:h2:mem:X2.db;INIT=CREATE SCHEMA IF NOT EXISTS X2;DB_CLOSE_DELAY=30;"),
+          jdbcDriver = Some("org.h2.Driver"),
+          jdbcUser = Some("ORACLE_X2_USER"),
+          jdbcPassword = Some("ORACLE_X2_PASS"),
+          jdbcFetchSize = 10
+        ),
+        "HIVE_CENSUS" -> SqlDataSourceConfig(
+          storageFormat = HiveFormat,
+          dataSourceName = "HIVE_CENSUS"
+        ),
+        "HIVE_X2" -> SqlDataSourceConfig(
+          storageFormat = HiveFormat,
+          dataSourceName = "HIVE_X2"
+        )
       )
     }
   }

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfigTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfigTest.scala
@@ -26,8 +26,8 @@
  */
 package org.opencypher.spark.api.io.sql
 
+import org.opencypher.spark.api.io.FileFormat
 import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.{File, Hive, Jdbc}
-import org.opencypher.spark.api.io.{CsvFormat, ParquetFormat}
 import org.scalatest.Matchers
 
 import scala.io.Source
@@ -45,8 +45,8 @@ class SqlDataSourceConfigTest extends org.scalatest.FunSpec with Matchers {
         Hive,
         Jdbc("foo", "driv"),
         Jdbc("foo", "driv", Map("foo" -> "bar")),
-        File(CsvFormat, None),
-        File(CsvFormat, Some("/foo/bar"), Map("foo" -> "bar2"))
+        File(FileFormat.csv, None),
+        File(FileFormat.csv, Some("/foo/bar"), Map("foo" -> "bar2"))
       ).foreach(cfg => roundTrip(cfg) shouldEqual cfg)
 
     }
@@ -73,7 +73,7 @@ class SqlDataSourceConfigTest extends org.scalatest.FunSpec with Matchers {
         "HIVE_CENSUS" -> Hive,
         "HIVE_X2" -> Hive,
         "MY_DIR" -> File(
-          format = ParquetFormat,
+          format = FileFormat.parquet,
           basePath = Some("/my/path")
         )
       )

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceAcceptanceTest.scala
@@ -88,7 +88,7 @@ abstract class SqlPropertyGraphDataSourceAcceptanceTest extends CAPSTestSuite wi
       writeTable(relDf, tableName)
     }
 
-    val sqlPgds = SqlPropertyGraphDataSource(graphDdl, List(sqlDataSourceConfig))
+    val sqlPgds = SqlPropertyGraphDataSource(graphDdl, Map(dataSourceName -> sqlDataSourceConfig))
 
     // The DDL cannot represent nodes without labels, so we need to wrap the data source and add this node manually
     val nodesWithoutLabels = CAPSScanGraphFactory(CreateGraphFactory(createStatementsForNodesWithoutLabels))

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceTest.scala
@@ -32,7 +32,7 @@ import org.opencypher.graphddl.GraphDdl
 import org.opencypher.okapi.api.graph.GraphName
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.testing.Bag
-import org.opencypher.spark.api.io.CsvFormat
+import org.opencypher.spark.api.io.FileFormat
 import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.{File, Hive, Jdbc}
 import org.opencypher.spark.api.value.{CAPSNode, CAPSRelationship}
 import org.opencypher.spark.impl.CAPSFunctions.{partitioned_id_assignment, rowIdSpaceBitsUsedByMonotonicallyIncreasingId}
@@ -527,7 +527,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
     val ds = SqlPropertyGraphDataSource(
       GraphDdl(ddlString),
       Map("csv" -> File(
-        format = CsvFormat,
+        format = FileFormat.csv,
         basePath = Some("file://" + getClass.getResource("/csv").getPath)
       ))
     )
@@ -565,7 +565,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
     val ds = SqlPropertyGraphDataSource(
       GraphDdl(ddlString),
       Map("csv" -> File(
-        format = CsvFormat
+        format = FileFormat.csv
       ))
     )
 

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceTest.scala
@@ -104,7 +104,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("foo")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$fooView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(0, Set("Foo"), CypherMap("foo" -> "Alice")))
@@ -133,7 +133,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("col1", "col2")
       .write.mode(SaveMode.Overwrite).mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$fooView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(0, Set("Foo"), CypherMap("key1" -> 42L, "key2" -> "Alice")))
@@ -170,7 +170,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("bar")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$barView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0), Set("Foo"), CypherMap("foo" -> "Alice"))),
@@ -219,7 +219,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("person", "book", "rating")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$readsView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive))
 
     val personId = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0)
     val bookId = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 1)
@@ -274,7 +274,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("source_id", "target_id", "id", "start", "end")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$relsView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive))
 
     val nodeId1 = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0)
     val nodeId2 = computePartitionedRowId(rowIndex = 1, partitionStartDelta = 0)
@@ -342,7 +342,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("p_id", "b_id", "rates")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$readsView2")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive))
 
     val personId = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0)
     val book1Id = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 1)
@@ -401,8 +401,8 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .write.mode(SaveMode.Overwrite).saveAsTable(s"db2.$barView")
 
     val configs = Map(
-      "ds1" -> Hive(),
-      "ds2" -> Hive()
+      "ds1" -> Hive,
+      "ds2" -> Hive
     )
     val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), configs)
 
@@ -429,7 +429,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
          |)
      """.stripMargin
 
-    val hiveDataSourceConfig = Hive()
+    val hiveDataSourceConfig = Hive
     val h2DataSourceConfig = Jdbc(
       driver = "org.h2.Driver",
       url = "jdbc:h2:mem:?user=sa&password=1234;DB_CLOSE_DELAY=-1"
@@ -484,7 +484,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
         |)
         """.stripMargin
 
-    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("ds1" -> Hive()))
+    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("ds1" -> Hive))
 
     pgds.graph(GraphName("fooGraph")).cypher("MATCH (n) RETURN n.int, n.long").records.toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n.int" -> 1, "n.long" -> 10),
@@ -501,7 +501,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
         |)
       """.stripMargin
 
-    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("known1" -> Hive(), "known2" -> Hive()))
+    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("known1" -> Hive, "known2" -> Hive))
 
     val e = the [SqlDataSourceConfigException] thrownBy pgds.graph(GraphName("g"))
     e.getMessage should (include("unknown") and include("known1") and include("known2"))

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSourceTest.scala
@@ -32,7 +32,8 @@ import org.opencypher.graphddl.GraphDdl
 import org.opencypher.okapi.api.graph.GraphName
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.testing.Bag
-import org.opencypher.spark.api.io.{CsvFormat, HiveFormat, JdbcFormat}
+import org.opencypher.spark.api.io.CsvFormat
+import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.{File, Hive, Jdbc}
 import org.opencypher.spark.api.value.{CAPSNode, CAPSRelationship}
 import org.opencypher.spark.impl.CAPSFunctions.{partitioned_id_assignment, rowIdSpaceBitsUsedByMonotonicallyIncreasingId}
 import org.opencypher.spark.testing.CAPSTestSuite
@@ -103,7 +104,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("foo")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$fooView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(SqlDataSourceConfig(HiveFormat, dataSourceName)))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(0, Set("Foo"), CypherMap("foo" -> "Alice")))
@@ -132,7 +133,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("col1", "col2")
       .write.mode(SaveMode.Overwrite).mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$fooView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(SqlDataSourceConfig(HiveFormat, dataSourceName)))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(0, Set("Foo"), CypherMap("key1" -> 42L, "key2" -> "Alice")))
@@ -169,7 +170,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("bar")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$barView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(SqlDataSourceConfig(HiveFormat, dataSourceName)))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0), Set("Foo"), CypherMap("foo" -> "Alice"))),
@@ -218,7 +219,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("person", "book", "rating")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$readsView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(SqlDataSourceConfig(HiveFormat, dataSourceName)))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
 
     val personId = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0)
     val bookId = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 1)
@@ -273,7 +274,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("source_id", "target_id", "id", "start", "end")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$relsView")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(SqlDataSourceConfig(HiveFormat, dataSourceName)))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
 
     val nodeId1 = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0)
     val nodeId2 = computePartitionedRowId(rowIndex = 1, partitionStartDelta = 0)
@@ -341,7 +342,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("p_id", "b_id", "rates")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$readsView2")
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(SqlDataSourceConfig(HiveFormat, dataSourceName)))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map(dataSourceName -> Hive()))
 
     val personId = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0)
     val book1Id = computePartitionedRowId(rowIndex = 0, partitionStartDelta = 1)
@@ -399,9 +400,9 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
       .toDF("bar")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"db2.$barView")
 
-    val configs = List(
-      SqlDataSourceConfig(HiveFormat, "ds1"),
-      SqlDataSourceConfig(HiveFormat, "ds2")
+    val configs = Map(
+      "ds1" -> Hive(),
+      "ds2" -> Hive()
     )
     val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), configs)
 
@@ -428,15 +429,10 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
          |)
      """.stripMargin
 
-    val hiveDataSourceConfig = SqlDataSourceConfig(
-      storageFormat = HiveFormat,
-      dataSourceName = "ds1"
-    )
-    val h2DataSourceConfig = SqlDataSourceConfig(
-      storageFormat = JdbcFormat,
-      dataSourceName = "ds2",
-      jdbcDriver = Some("org.h2.Driver"),
-      jdbcUri = Some("jdbc:h2:mem:?user=sa&password=1234;DB_CLOSE_DELAY=-1")
+    val hiveDataSourceConfig = Hive()
+    val h2DataSourceConfig = Jdbc(
+      driver = "org.h2.Driver",
+      url = "jdbc:h2:mem:?user=sa&password=1234;DB_CLOSE_DELAY=-1"
     )
     // -- Add hive data
 
@@ -457,7 +453,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
 
     // -- Read graph and validate
 
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(hiveDataSourceConfig, h2DataSourceConfig))
+    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("ds1" -> hiveDataSourceConfig, "ds2" -> h2DataSourceConfig))
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(computePartitionedRowId(rowIndex = 0, partitionStartDelta = 0), Set("Foo"), CypherMap("foo" -> "Alice"))),
@@ -488,12 +484,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
         |)
         """.stripMargin
 
-    val hiveDataSourceConfig = SqlDataSourceConfig(
-      storageFormat = HiveFormat,
-      dataSourceName = "ds1"
-    )
-
-    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(hiveDataSourceConfig))
+    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("ds1" -> Hive()))
 
     pgds.graph(GraphName("fooGraph")).cypher("MATCH (n) RETURN n.int, n.long").records.toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n.int" -> 1, "n.long" -> 10),
@@ -510,10 +501,7 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
         |)
       """.stripMargin
 
-    val known1 = SqlDataSourceConfig(HiveFormat, "known1")
-    val known2 = SqlDataSourceConfig(HiveFormat, "known2")
-
-    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(known1, known2))
+    val pgds = SqlPropertyGraphDataSource(GraphDdl(ddlString), Map("known1" -> Hive(), "known2" -> Hive()))
 
     val e = the [SqlDataSourceConfigException] thrownBy pgds.graph(GraphName("g"))
     e.getMessage should (include("unknown") and include("known1") and include("known2"))
@@ -535,14 +523,14 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
          |)
      """.stripMargin
 
-    val csvDataSourceConfig = SqlDataSourceConfig(
-      storageFormat = CsvFormat,
-      dataSourceName = "csv",
-      basePath = Some("file://" + getClass.getResource("/csv").getPath)
-    )
-
     // -- Read graph and validate
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(csvDataSourceConfig))
+    val ds = SqlPropertyGraphDataSource(
+      GraphDdl(ddlString),
+      Map("csv" -> File(
+        format = CsvFormat,
+        basePath = Some("file://" + getClass.getResource("/csv").getPath)
+      ))
+    )
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(0, Set("Person"), CypherMap("id" -> 1, "name" -> "Alice"))),
@@ -573,13 +561,13 @@ class SqlPropertyGraphDataSourceTest extends CAPSTestSuite with HiveFixture with
          |)
      """.stripMargin
 
-    val csvDataSourceConfig = SqlDataSourceConfig(
-      storageFormat = CsvFormat,
-      dataSourceName = "csv"
-    )
-
     // -- Read graph and validate
-    val ds = SqlPropertyGraphDataSource(GraphDdl(ddlString), List(csvDataSourceConfig))
+    val ds = SqlPropertyGraphDataSource(
+      GraphDdl(ddlString),
+      Map("csv" -> File(
+        format = CsvFormat
+      ))
+    )
 
     ds.graph(fooGraphName).nodes("n").toMapsWithCollectedEntities should equal(Bag(
       CypherMap("n" -> CAPSNode(0, Set("Person"), CypherMap("id" -> 1, "name" -> "Alice"))),

--- a/spark-cypher/LICENSES.txt
+++ b/spark-cypher/LICENSES.txt
@@ -259,6 +259,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -266,8 +267,11 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/spark-cypher/NOTICE.txt
+++ b/spark-cypher/NOTICE.txt
@@ -50,6 +50,7 @@ BSD-3-Clause
   scala-xml_2.11-1.0.5.jar
 
 MIT
+  acyclic_2.11-0.1.5.jar
   cats-core_2.11-1.0.1.jar
   cats-kernel_2.11-1.0.1.jar
   cats-macros_2.11-1.0.1.jar
@@ -57,5 +58,8 @@ MIT
   fastparse_2.11-2.1.0.jar
   machinist_2.11-0.6.2.jar
   sourcecode_2.11-0.1.5.jar
-  ujson_2.11-0.6.6.jar
-  upickle_2.11-0.6.6.jar
+  ujson_2.11-0.7.1.jar
+  upack_2.11-0.7.1.jar
+  upickle-core_2.11-0.7.1.jar
+  upickle-implicits_2.11-0.7.1.jar
+  upickle_2.11-0.7.1.jar

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/GraphSources.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/GraphSources.scala
@@ -121,14 +121,16 @@ object SqlGraphSources {
     def withIdGenerationStrategy(idGenerationStrategy: IdGenerationStrategy): SqlGraphSourceFactory =
       copy(idGenerationStrategy = idGenerationStrategy)
 
-
     def withSqlDataSourceConfigs(sqlDataSourceConfigsPath: String): SqlPropertyGraphDataSource = {
       val jsonString = Source.fromFile(sqlDataSourceConfigsPath, "UTF-8").getLines().mkString(Properties.lineSeparator)
-      val sqlDataSourceConfigs = SqlDataSourceConfig.dataSourcesFromString(jsonString).values.toList
+      val sqlDataSourceConfigs = SqlDataSourceConfig.dataSourcesFromString(jsonString)
       withSqlDataSourceConfigs(sqlDataSourceConfigs)
     }
 
-    def withSqlDataSourceConfigs(sqlDataSourceConfigs: List[SqlDataSourceConfig]): SqlPropertyGraphDataSource =
+    def withSqlDataSourceConfigs(sqlDataSourceConfigs: (String, SqlDataSourceConfig)*): SqlPropertyGraphDataSource =
+      withSqlDataSourceConfigs(sqlDataSourceConfigs.toMap)
+
+    def withSqlDataSourceConfigs(sqlDataSourceConfigs: Map[String, SqlDataSourceConfig]): SqlPropertyGraphDataSource =
       SqlPropertyGraphDataSource(graphDdl, sqlDataSourceConfigs, idGenerationStrategy)
   }
 

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/GraphSources.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/GraphSources.scala
@@ -28,14 +28,14 @@ package org.opencypher.spark.api
 
 import java.nio.file.Paths
 
+import org.opencypher.graphddl.GraphDdl
 import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.neo4j.io.Neo4jConfig
+import org.opencypher.spark.api.io.FileFormat
 import org.opencypher.spark.api.io.fs.{EscapeAtSymbol, FSGraphSource}
 import org.opencypher.spark.api.io.neo4j.{Neo4jBulkCSVDataSink, Neo4jPropertyGraphDataSource}
-import org.opencypher.spark.api.io.sql.{SqlDataSourceConfig, SqlPropertyGraphDataSource}
-import org.opencypher.spark.api.io.{CsvFormat, OrcFormat, ParquetFormat}
-import org.opencypher.graphddl.GraphDdl
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy.IdGenerationStrategy
+import org.opencypher.spark.api.io.sql.{SqlDataSourceConfig, SqlPropertyGraphDataSource}
 
 import scala.io.Source
 import scala.util.Properties
@@ -65,11 +65,11 @@ object FSGraphSources {
     filesPerTable: Option[Int] = Some(1)
   )(implicit session: CAPSSession) {
 
-    def csv: FSGraphSource = new FSGraphSource(rootPath, CsvFormat, hiveDatabaseName, filesPerTable)
+    def csv: FSGraphSource = new FSGraphSource(rootPath, FileFormat.csv, hiveDatabaseName, filesPerTable)
 
-    def parquet: FSGraphSource = new FSGraphSource(rootPath, ParquetFormat, hiveDatabaseName, filesPerTable)
+    def parquet: FSGraphSource = new FSGraphSource(rootPath, FileFormat.parquet, hiveDatabaseName, filesPerTable)
 
-    def orc: FSGraphSource = new FSGraphSource(rootPath, OrcFormat, hiveDatabaseName, filesPerTable) with EscapeAtSymbol
+    def orc: FSGraphSource = new FSGraphSource(rootPath, FileFormat.orc, hiveDatabaseName, filesPerTable) with EscapeAtSymbol
   }
 
   /**

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/StorageFormat.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/StorageFormat.scala
@@ -28,7 +28,7 @@ package org.opencypher.spark.api.io
 
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
 import org.opencypher.okapi.impl.util.JsonUtils.FlatOption._
-import upickle.Js
+import ujson._
 
 trait StorageFormat {
   def name: String = getClass.getSimpleName.dropRight("Format$".length).toLowerCase
@@ -46,7 +46,7 @@ object StorageFormat {
     ParquetFormat.name -> ParquetFormat
   )
 
-  implicit def rw: ReadWriter[StorageFormat] = readwriter[Js.Value].bimap[StorageFormat](
+  implicit def rw: ReadWriter[StorageFormat] = readwriter[Value].bimap[StorageFormat](
     storageFormat => storageFormat.name,
     storageFormatName => allStorageFormats.getOrElse(storageFormatName.str,
       throw IllegalArgumentException(s"Supported storage format (one of ${allStorageFormats.keys.mkString("[", ", ", "]")})", storageFormatName.str)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/neo4j/Neo4jBulkCSVDataSink.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/neo4j/Neo4jBulkCSVDataSink.scala
@@ -36,7 +36,7 @@ import org.opencypher.spark.api.io.fs.DefaultGraphDirectoryStructure._
 import org.opencypher.spark.api.io.fs.FSGraphSource
 import org.opencypher.spark.api.io.fs.HadoopFSHelpers._
 import org.opencypher.spark.api.io.neo4j.Neo4jBulkCSVDataSink._
-import org.opencypher.spark.api.io.{CsvFormat, GraphEntity, Relationship}
+import org.opencypher.spark.api.io.{FileFormat, GraphEntity, Relationship}
 import org.opencypher.spark.schema.CAPSSchema
 
 object Neo4jBulkCSVDataSink {
@@ -89,7 +89,7 @@ object Neo4jBulkCSVDataSink {
   * @param session        CAPS session
   */
 class Neo4jBulkCSVDataSink(override val rootPath: String, arrayDelimiter: String = "|")(implicit session: CAPSSession)
-  extends FSGraphSource(rootPath, CsvFormat) {
+  extends FSGraphSource(rootPath, FileFormat.csv) {
 
   override protected def writeSchema(
     graphName: GraphName,

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfig.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfig.scala
@@ -26,7 +26,7 @@
  */
 package org.opencypher.spark.api.io.sql
 
-import org.opencypher.spark.api.io.{HiveFormat, JdbcFormat, StorageFormat, TabularFileFormat}
+import org.opencypher.spark.api.io.{FileFormat, HiveFormat, JdbcFormat, StorageFormat}
 import ujson.Value
 
 import scala.util.{Failure, Success, Try}
@@ -103,7 +103,7 @@ object SqlDataSourceConfig {
     */
   @upickle.implicits.key("file")
   case class File(
-    override val format: TabularFileFormat,
+    override val format: FileFormat,
     basePath: Option[String] = None,
     override val options: Map[String, String] = Map.empty
   ) extends SqlDataSourceConfig(format, options)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfig.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfig.scala
@@ -66,6 +66,8 @@ case class SqlDataSourceConfig(
   defaultSchema: Option[String] = None,
   jdbcUri: Option[String] = None,
   jdbcDriver: Option[String] = None,
+  jdbcUser: Option[String] = None,
+  jdbcPassword: Option[String] = None,
   jdbcFetchSize: Int = 100,
   basePath: Option[String] = None
 ) {

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfig.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlDataSourceConfig.scala
@@ -43,7 +43,7 @@ sealed abstract class SqlDataSourceConfig(
 
 object SqlDataSourceConfig {
   private implicit val jdbc: ReadWriter[Jdbc] = macroRW
-  private implicit val hive: ReadWriter[Hive] = macroRW
+  private implicit val hive: ReadWriter[Hive.type] = macroRW
   private implicit val file: ReadWriter[File] = macroRW
   private val defaultMacroRW: ReadWriter[SqlDataSourceConfig] = macroRW
 
@@ -76,14 +76,6 @@ object SqlDataSourceConfig {
         throw SqlDataSourceConfigException(s"Malformed SQL configuration file: ${ex.getMessage}", ex)
     }
 
-//  * @param storageFormat  the interface between the SQL PGDS and the SQL data source. Supported values are hive and jdbc.
-//  * @param dataSourceName the user-defined name of the data source.
-//  * @param defaultSchema  the default SQL schema to use in this data source. Can be overridden by SET SCHEMA in Graph DDL.
-//    * @param jdbcUri
-//  * @param jdbcDriver     classname of the JDBC driver to use for the JDBC connection
-//  * @param jdbcFetchSize  the fetch size to use for transferring data over JDBC
-//    * @param basePath       the root folder used for file based formats
-
   /** Configures a data source that reads tables via JDBC
     *
     * @param url     the JDBC URI to use when connecting to the JDBC server
@@ -101,8 +93,7 @@ object SqlDataSourceConfig {
     * @note The Spark session needs to be configured with `.enableHiveSupport()`
     */
   @upickle.implicits.key("hive")
-  case class Hive(
-  ) extends SqlDataSourceConfig(HiveFormat, Map.empty)
+  case object Hive extends SqlDataSourceConfig(HiveFormat, Map.empty)
 
   /** Configures a data source that reads tables from files
     *

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
@@ -228,13 +228,11 @@ case class SqlPropertyGraphDataSource(
     }
   }
 
-  private def readFile(viewId: ViewId, dataSourceConfig: File) = {
+  private def readFile(viewId: ViewId, dataSourceConfig: File): DataFrame = {
     val spark = caps.sparkSession
 
     val optionsByFormat: Map[StorageFormat, Map[String, String]] = Map(
-      CsvFormat -> Map("header" -> "true", "inferSchema" -> "true"),
-      OrcFormat -> Map.empty,
-      ParquetFormat -> Map.empty
+      FileFormat.csv -> Map("header" -> "true", "inferSchema" -> "true")
     )
 
     val viewPath = (viewId.maybeSetSchema, viewId.parts) match {
@@ -254,7 +252,7 @@ case class SqlPropertyGraphDataSource(
 
     spark.read
       .format(dataSourceConfig.format.name)
-      .options(optionsByFormat(dataSourceConfig.format))
+      .options(optionsByFormat.getOrElse(dataSourceConfig.format, Map.empty))
       .options(dataSourceConfig.options)
       .load(filePath.toString)
   }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
@@ -34,7 +34,6 @@ import org.opencypher.graphddl._
 import org.opencypher.okapi.api.graph.{GraphName, PropertyGraph}
 import org.opencypher.okapi.api.io.conversion.{EntityMapping, NodeMapping, RelationshipMapping}
 import org.opencypher.okapi.impl.exception.{GraphNotFoundException, IllegalArgumentException, UnsupportedOperationException}
-import org.opencypher.okapi.impl.util.StringEncodingUtilities
 import org.opencypher.okapi.impl.util.StringEncodingUtilities._
 import org.opencypher.spark.api.CAPSSession
 import org.opencypher.spark.api.io.AbstractPropertyGraphDataSource._
@@ -43,7 +42,6 @@ import org.opencypher.spark.api.io.Relationship.{sourceEndNodeKey, sourceStartNo
 import org.opencypher.spark.api.io._
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy._
 import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.{File, Hive, Jdbc}
-import org.opencypher.spark.impl.DataFrameOps._
 import org.opencypher.spark.impl.io.CAPSPropertyGraphDataSource
 import org.opencypher.spark.impl.table.SparkTable._
 import org.opencypher.spark.schema.CAPSSchema


### PR DESCRIPTION
Rework the data source configs
- Specific case classes for different data source types enabling
  - Better config scala API
  - Early validation of configuration
- Update examples to show API config over JSON config
- Make json representation a map instead of a list

Scala api:
```scala
GraphSources
  .sql("my.ddl")
  .withSqlDataSourceConfigs(
    "CENSUS_ORACLE" -> Jdbc(
      url = "<jdbc url>",
      driver = "org.h2.Driver"
    ),
    "ORACLE_X2" -> Jdbc(
      url = "<jdbc url>",
      driver = "org.h2.Driver",
      options = Map(
        "user" -> "ORACLE_X2_USER",
        "password" -> "ORACLE_X2_PASS",
        "fetchSize" -> "10"
      )
    ),
    "HIVE_CENSUS" -> Hive(),
    "HIVE_X2" -> Hive(),
    "MY_DIR" -> File(
      format = ParquetFormat,
      basePath = Some("/my/path")
    )
  )
```

Json now looks like:
```json
{
  "CENSUS_ORACLE": {
    "type": "jdbc",
    "url": "<jdbc url>",
    "driver": "org.h2.Driver"
  },

  "ORACLE_X2": {
    "type": "jdbc",
    "url": "<jdbc url>",
    "driver": "org.h2.Driver",
    "options": {
      "user": "ORACLE_X2_USER",
      "password": "ORACLE_X2_PASS",
      "fetchSize": "10"
    }
  },

  "HIVE_CENSUS": {
    "type": "hive"
  },

  "HIVE_X2": {
    "type": "hive"
  },

  "MY_DIR": {
    "type": "file",
    "format": "parquet",
    "basePath": "/my/path"
  }
}
```