### PR TITLE
Enable scalac plugin to fail on `???`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ subprojects {
         mavenLocal()
     }
 
+    configurations {
+        scalaCompilerPlugin
+    }
+
     dependencies {
         compile group: 'org.scala-lang', name: 'scala-library',  version: ver.scala.full
 
@@ -33,6 +37,9 @@ subprojects {
         testCompile group: 'org.scalatest',      name: "scalatest".scala(),     version: ver.scalatest
         testCompile group: 'org.scalacheck',     name: "scalacheck".scala(),    version: ver.scalacheck
         testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: ver.junit.runner
+
+        if (cfg.enableNotImplementedCheck())
+            scalaCompilerPlugin group: "com.github.cb372", name: "scala-typed-holes_$ver.scala.full", version: "0.0.6"
     }
 
     test {
@@ -50,6 +57,11 @@ subprojects {
             '-Yopt-warnings:at-inline-failed',
             '-Yopt:l:project',
             '-Ypartial-unification',
+    ]
+
+    if (cfg.enableNotImplementedCheck()) scalacParameters += [
+        "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+        "-P:typed-holes:log-level:error",
     ]
 
     tasks.withType(ScalaCompile) {

--- a/build.params.gradle
+++ b/build.params.gradle
@@ -1,7 +1,9 @@
 ext {
 
     cfg = [
-            publishDir: "build/repo",
+            ci                       : false,
+            publishDir               : "build/repo",
+            enableNotImplementedCheck: { cfg.ci.toBoolean() },
     ]
 
     ver = [


### PR DESCRIPTION
Enables build failure if `???` is encountered in the code

```
$ gradle graph-ddl:classes -Pcfg.ci=true

> Task :graph-ddl:compileScala FAILED
Pruning sources from previous analysis, due to incompatible CompileSetup.
/home/tobias/Projects/cypher-for-apache-spark/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdl.scala:46: Found hole with type: String
  def x: String = ???
                  ^
one error found

FAILURE: Build failed with an exception.
```

Uses https://github.com/cb372/scala-typed-holes, which is at version 0.0.6