### PR TITLE
Remove unnecessary aliasing in df.castToLong helper

### DIFF
--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -373,7 +373,7 @@ object SparkTable {
     }
 
     def safeRenameColumns(renamings: Map[String, String]): DataFrame = {
-      if (renamings.forall { case (oldColumn, newColumn) => oldColumn == newColumn }) {
+      if (renamings.isEmpty || renamings.forall { case (oldColumn, newColumn) => oldColumn == newColumn }) {
         df
       } else {
         renamings.foreach { case (oldName, newName) => require(!df.columns.contains(newName),
@@ -422,7 +422,7 @@ object SparkTable {
       */
     def castToLong: DataFrame = {
       def convertColumns(field: StructField, col: Column): Column = {
-        val converted = field.dataType match {
+        field.dataType match {
           case StructType(inner) =>
             val fields = inner.map(i => convertColumns(i, col.getField(i.name)))
             functions.struct(fields: _*)
@@ -430,7 +430,6 @@ object SparkTable {
           case IntegerType => col.cast(LongType)
           case _ => col
         }
-        converted.as(field.name)
       }
 
       val convertedFields = df.schema.fields.map { field => convertColumns(field, df.col(field.name)) }

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/table/SparkTable.scala
@@ -432,10 +432,8 @@ object SparkTable {
         }
         if (col == convertedCol) col else convertedCol.as(field.name)
       }
-
-      val convertedFields = df.schema.fields.map { field => convertColumns(field, df.col(field.name)) }
-
-      df.select(convertedFields: _*)
+      val convertedColumns = df.schema.fields.map { field => convertColumns(field, df.col(field.name)) }
+      if (df.columns.map(df.col).sameElements(convertedColumns)) df else df.select(convertedColumns: _*)
     }
 
     /**


### PR DESCRIPTION
For TPC-H Query 14 the additional aliasing resulted in an issue within the `InferFiltersFromConstraints` rewriter in Catalyst. Will try to reproduce the bug with plain dataframes and report to Spark Jira.

* fixes #773 