### PR TITLE
Some tweaks to license checking

### DIFF
--- a/build.licenses.gradle
+++ b/build.licenses.gradle
@@ -184,7 +184,7 @@ subprojects {
               existing : file("$projectDir/NOTICE.txt")],
             ].each {
                 if (it.generated.text != it.existing.text) {
-                    throw new GradleException("Generated file differs from the existing file.\n Generated: $file.generated \n Existing: $file.existing")
+                    throw new GradleException("Generated file differs from the existing file.\n Generated: $it.generated \n Existing: $it.existing")
                 }
             }
         }

--- a/build.licenses.gradle
+++ b/build.licenses.gradle
@@ -100,19 +100,6 @@ subprojects {
 
         dependencyConfiguration = 'compile'
 
-        licenses = [
-                'org.antlr:antlr-runtime:3.4'              : 'BSD-3-Clause', // https://www.antlr3.org/license.html
-                'asm:asm:3.1'                              : 'BSD-3-Clause', // https://gitlab.ow2.org/asm/asm/blob/master/LICENSE.txt
-                'commons-beanutils:commons-beanutils:1.7.0': 'Apache-2.0', // http://commons.apache.org/proper/commons-beanutils/
-                'oro:oro:2.0.8'                            : 'Apache-2.0', // https://mvnrepository.com/artifact/oro/oro/2.0.8
-                'org.codehaus.jettison:jettison:1.1'       : 'Apache-2.0', // https://github.com/codehaus/jettison/tree/jettison-1.1
-                'org.apache.zookeeper:zookeeper:3.4.6'     : 'Apache-2.0', // https://github.com/apache/zookeeper/tree/branch-3.4
-                'org.apache.xbean:xbean-asm5-shaded:4.4'   : 'Apache-2.0', // https://mvnrepository.com/artifact/org.apache.xbean/xbean-asm5-shaded/4.4
-                'javax.servlet:servlet-api:2.5'            : 'CDDL-1.1+GPL-2.0+CPE', // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
-                'javax.transaction:jta:1.1'                : 'CDDL-1.1+GPL-2.0+CPE', // https://github.com/javaee/javax.transaction/blob/master/LICENSE
-                'javax.servlet.jsp:jsp-api:2.1'            : 'CDDL-1.1+GPL-2.0+CPE', // https://javaee.github.io/javaee-jsp-api/LICENSE
-        ]
-
         aliases = whitelist.collectEntries { lic ->
             def actual = license(lic.name, lic.url)
             def alternatives = lic.aliases.collect { it.url ? license(it.name, it.url) : it.name }

--- a/build.publishing.gradle
+++ b/build.publishing.gradle
@@ -21,6 +21,26 @@ subprojects {
                             .findResults { tasks.findByName(it) }
                             .each { artifact it }
                 }
+
+                pom {
+                    licenses {
+                        license {
+                            name = 'Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'caps'
+                            name = 'The CAPS team'
+                            email = 'opencypher@neo4j.com'
+                            url = 'https://www.opencypher.org'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/opencypher/cypher-for-apache-spark'
+                    }
+                }
             }
 
             full(MavenPublication) {

--- a/spark-cypher/build.gradle
+++ b/spark-cypher/build.gradle
@@ -20,4 +20,5 @@ shadowJar {
     dependencies {
         exclude(dependency('org.scala-lang:'))
     }
+    exclude "META-INF/versions/**/*"
 }


### PR DESCRIPTION
Without the license info in the poms, downstream projects that depend on CAPS and also does license checking can fail. The info is in the poms when we release, but including them also in the "dev" publication is cheap and allows building downstreams against local dev CAPS without hacking license validation.