### PR TITLE
Implement EXTENDS syntax for Graph DDL

### DIFF
--- a/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlAst.scala
+++ b/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlAst.scala
@@ -57,6 +57,7 @@ case class SetSchemaDefinition(
 
 case class ElementTypeDefinition(
   name: String,
+  parents: Set[String] = Set.empty,
   properties: Map[String, CypherType] = Map.empty,
   maybeKey: Option[KeyDefinition] = None
 ) extends GraphDdlAst with DdlStatement with GraphTypeStatement

--- a/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlException.scala
+++ b/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlException.scala
@@ -36,7 +36,7 @@ abstract class GraphDdlException(msg: String, cause: Option[Exception] = None) e
 private[graphddl] object GraphDdlException {
 
   def unresolved(desc: String, reference: Any): Nothing = throw UnresolvedReferenceException(
-    s"""$desc: $reference"""
+    s"$desc: $reference"
   )
 
   def unresolved(desc: String, reference: Any, available: Traversable[Any]): Nothing = throw UnresolvedReferenceException(
@@ -45,7 +45,11 @@ private[graphddl] object GraphDdlException {
   )
 
   def duplicate(desc: String, definition: Any): Nothing = throw DuplicateDefinitionException(
-    s"""$desc: $definition"""
+    s"$desc: $definition"
+  )
+
+  def illegalInheritance(desc: String, reference: Any): Nothing = throw IllegalInheritanceException(
+    s"$desc: $reference"
   )
 
   def incompatibleTypes(msg: String): Nothing =
@@ -72,6 +76,8 @@ private[graphddl] object GraphDdlException {
 case class UnresolvedReferenceException(msg: String, cause: Option[Exception] = None) extends GraphDdlException(msg, cause)
 
 case class DuplicateDefinitionException(msg: String, cause: Option[Exception] = None) extends GraphDdlException(msg, cause)
+
+case class IllegalInheritanceException(msg: String, cause: Option[Exception] = None) extends GraphDdlException(msg, cause)
 
 case class TypeException(msg: String, cause: Option[Exception] = None) extends GraphDdlException(msg, cause)
 

--- a/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlParser.scala
+++ b/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlParser.scala
@@ -87,7 +87,7 @@ object GraphDdlParser {
     P(identifier.! ~/ CypherTypeParser.cypherType)
 
   private def properties[_: P]: P[Map[String, CypherType]] =
-    P("(" ~/ property.rep(min = 1, sep = ",").map(_.toMap) ~/ ")")
+    P("(" ~/ property.rep(min = 0, sep = ",").map(_.toMap) ~/ ")")
 
   private def keyDefinition[_: P]: P[(String, Set[String])] =
     P(KEY ~/ identifier.! ~/ "(" ~/ identifier.!.rep(min = 1, sep = ",").map(_.toSet) ~/ ")")

--- a/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlParser.scala
+++ b/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdlParser.scala
@@ -97,8 +97,9 @@ object GraphDdlParser {
     P(EXTENDS ~/ identifier.!.rep(min = 1, sep = ",").map(_.toSet))
 
   def elementTypeDefinition[_: P]: P[ElementTypeDefinition] =
-    P(identifier.! ~/ extendsDefinition.?.map(_.getOrElse(Set.empty)) ~/ properties.?.map(_.getOrElse(Map.empty)) ~/ keyDefinition.?).map {
-      case (id, parents, props, maybeKey) => ElementTypeDefinition(id, parents, props, maybeKey)
+    P(identifier.! ~/ extendsDefinition.? ~/ properties.? ~/ keyDefinition.?).map {
+      case (id, maybeParents, maybeProps, maybeKey) =>
+        ElementTypeDefinition(id, maybeParents.getOrElse(Set.empty), maybeProps.getOrElse(Map.empty), maybeKey)
     }
 
   def globalElementTypeDefinition[_: P]: P[ElementTypeDefinition] =

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlAcceptanceTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlAcceptanceTest.scala
@@ -284,10 +284,10 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
       ddlDefinition should equalWithTracing(
         DdlDefinition(List(
           SetSchemaDefinition("foo", "bar"),
-          ElementTypeDefinition("A", Map("name" -> CTString)),
-          ElementTypeDefinition("B", Map("sequence" -> CTInteger, "nationality" -> CTString.nullable, "age" -> CTInteger.nullable)),
+          ElementTypeDefinition("A", properties = Map("name" -> CTString)),
+          ElementTypeDefinition("B", properties = Map("sequence" -> CTInteger, "nationality" -> CTString.nullable, "age" -> CTInteger.nullable)),
           ElementTypeDefinition("TYPE_1"),
-          ElementTypeDefinition("TYPE_2", Map("prop" -> CTBoolean.nullable)),
+          ElementTypeDefinition("TYPE_2", properties = Map("prop" -> CTBoolean.nullable)),
           GraphTypeDefinition(
             name = typeName,
             statements = List(

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlAcceptanceTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlAcceptanceTest.scala
@@ -259,7 +259,8 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
             |  (B),
             |  (C),
             |  (D),
-            |  (A, E)
+            |  (A, E),
+            |  (D, E)
             |)
             |CREATE GRAPH $graphName OF $typeName ()
             |""".stripMargin
@@ -271,6 +272,7 @@ class GraphDdlAcceptanceTest extends BaseTestSuite {
           .withNodePropertyKeys("A", "C")("a" -> CTString, "c" -> CTString)
           .withNodePropertyKeys("A", "B", "C", "D")("a" -> CTString, "b" -> CTString, "c" -> CTString, "d" -> CTInteger)
           .withNodePropertyKeys("A", "E")("a" -> CTString, "e" -> CTFloat)
+          .withNodePropertyKeys("A", "B", "C", "D", "E")("a" -> CTString, "b" -> CTString, "c" -> CTString, "d" -> CTInteger, "e" -> CTFloat)
       )
     }
 

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlParserTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlParserTest.scala
@@ -138,8 +138,8 @@ class GraphDdlParserTest extends BaseTestSuite with MockitoSugar with TestNameFi
       success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTLocalDateTimeOrNull)))
     }
 
-    it("!parses  A ()") {
-      failure(elementTypeDefinition(_))
+    it("parses A ()") {
+      success(elementTypeDefinition(_), ElementTypeDefinition("A"))
     }
   }
 

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlParserTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlParserTest.scala
@@ -97,21 +97,21 @@ class GraphDdlParserTest extends BaseTestSuite with MockitoSugar with TestNameFi
     }
   }
 
-  describe("label definitions") {
+  describe("element type definitions") {
     it("parses A") {
       success(elementTypeDefinition(_), ElementTypeDefinition("A"))
     }
 
     it("parses  A ( foo  string? )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("foo" -> CTString.nullable)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("foo" -> CTString.nullable)))
     }
 
     it("parses  A ( key FLOAT )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTFloat)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key" -> CTFloat)))
     }
 
     it("parses  A ( key FLOAT? )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTFloat.nullable)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key" -> CTFloat.nullable)))
     }
 
     it("!parses  A ( key _ STRING )") {
@@ -119,45 +119,57 @@ class GraphDdlParserTest extends BaseTestSuite with MockitoSugar with TestNameFi
     }
 
     it("parses  A ( key1 FLOAT, key2 STRING)") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key1" -> CTFloat, "key2" -> CTString)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key1" -> CTFloat, "key2" -> CTString)))
     }
 
     it("parses A ( key DATE )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTDate)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key" -> CTDate)))
     }
 
     it("parses A ( key DATE? )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTDateOrNull)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key" -> CTDateOrNull)))
     }
 
     it("parses A ( key LOCALDATETIME )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTLocalDateTime)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key" -> CTLocalDateTime)))
     }
 
     it("parses A ( key LOCALDATETIME? )") {
-      success(elementTypeDefinition(_), ElementTypeDefinition("A", Map("key" -> CTLocalDateTimeOrNull)))
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("key" -> CTLocalDateTimeOrNull)))
     }
 
     it("parses A ()") {
       success(elementTypeDefinition(_), ElementTypeDefinition("A"))
     }
+
+    it("parses A EXTENDS B ()") {
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", parents = Set("B")))
+    }
+
+    it("parses A EXTENDS B, C ()") {
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", parents = Set("B", "C")))
+    }
+
+    it("parses A EXTENDS B, C ( key STRING )") {
+      success(elementTypeDefinition(_), ElementTypeDefinition("A", parents = Set("B", "C"), properties = Map("key" -> CTString)))
+    }
   }
 
-  describe("catalog label definition") {
+  describe("catalog element type definition") {
     it("parses CREATE ELEMENT TYPE A") {
       success(globalElementTypeDefinition(_), ElementTypeDefinition("A"))
     }
 
     it("parses CREATE ELEMENT TYPE A ( foo STRING ) ") {
-      success(globalElementTypeDefinition(_), ElementTypeDefinition("A", Map("foo" -> CTString)))
+      success(globalElementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("foo" -> CTString)))
     }
 
     it("parses CREATE ELEMENT TYPE A KEY A_NK   (foo,   bar)") {
-      success(globalElementTypeDefinition(_), ElementTypeDefinition("A", Map.empty, Some("A_NK" -> Set("foo", "bar"))))
+      success(globalElementTypeDefinition(_), ElementTypeDefinition("A", properties = Map.empty, maybeKey = Some("A_NK" -> Set("foo", "bar"))))
     }
 
     it("parses CREATE ELEMENT TYPE A ( foo STRING ) KEY A_NK (foo,   bar)") {
-      success(globalElementTypeDefinition(_), ElementTypeDefinition("A", Map("foo" -> CTString), Some("A_NK" -> Set("foo", "bar"))))
+      success(globalElementTypeDefinition(_), ElementTypeDefinition("A", properties = Map("foo" -> CTString), maybeKey = Some("A_NK" -> Set("foo", "bar"))))
     }
 
     it("!parses CREATE ELEMENT TYPE A ( foo STRING ) KEY A ()") {
@@ -240,10 +252,10 @@ class GraphDdlParserTest extends BaseTestSuite with MockitoSugar with TestNameFi
            |CREATE ELEMENT TYPE TYPE_2 ( prop BOOLEAN? ) """.stripMargin) shouldEqual
         DdlDefinition(List(
           SetSchemaDefinition("foo", "bar"),
-          ElementTypeDefinition("A", Map("name" -> CTString)),
-          ElementTypeDefinition("B", Map("sequence" -> CTInteger, "nationality" -> CTString.nullable, "age" -> CTInteger.nullable)),
+          ElementTypeDefinition("A", properties = Map("name" -> CTString)),
+          ElementTypeDefinition("B", properties = Map("sequence" -> CTInteger, "nationality" -> CTString.nullable, "age" -> CTInteger.nullable)),
           ElementTypeDefinition("TYPE_1"),
-          ElementTypeDefinition("TYPE_2", Map("prop" -> CTBoolean.nullable))
+          ElementTypeDefinition("TYPE_2", properties = Map("prop" -> CTBoolean.nullable))
         ))
     }
 

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlTest.scala
@@ -588,5 +588,20 @@ class GraphDdlTest extends FunSpec with Matchers {
         """.stripMargin)
       e.getFullMessage should (include("fooGraph") and include("Employee") and include("MissingPerson"))
     }
+
+    it("fails on cyclic element type inheritance") {
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |SET SCHEMA a.b
+          |CREATE GRAPH fooGraph (
+          |  A EXTENDS B ( a STRING ),
+          |  B EXTENDS A ( b STRING ),
+          |
+          |  (A) FROM a ( A_a AS a, B_b AS b ),
+          |  (B) FROM b ( A_a AS a, B_b AS b )
+          |)
+        """.stripMargin)
+      e.getFullMessage should (include("Circular dependency") and include("A -> B -> A"))
+    }
   }
 }

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlTest.scala
@@ -603,5 +603,20 @@ class GraphDdlTest extends FunSpec with Matchers {
         """.stripMargin)
       e.getFullMessage should (include("Circular dependency") and include("A -> B -> A"))
     }
+
+    it("fails on conflicting property types in inheritance hierarchy") {
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |SET SCHEMA a.b
+          |CREATE GRAPH fooGraph (
+          |  A ( x STRING ),
+          |  B ( x INTEGER ),
+          |  C EXTENDS A, B (),
+          |
+          |  (C)
+          |)
+        """.stripMargin)
+      e.getFullMessage should (include("(A,B,C)") and include("x") and include("INTEGER") and include("STRING"))
+    }
   }
 }

--- a/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlTest.scala
+++ b/graph-ddl/src/test/scala/org/opencypher/graphddl/GraphDdlTest.scala
@@ -72,9 +72,9 @@ class GraphDdlTest extends FunSpec with Matchers {
 
     val personKey1 = NodeViewKey(NodeType("Person"), ViewId(maybeSetSchema, List("personView1")))
     val personKey2 = NodeViewKey(NodeType("Person"), ViewId(maybeSetSchema, List("personView2")))
-    val bookKey    = NodeViewKey(NodeType("Book"),   ViewId(maybeSetSchema, List("bookView")))
-    val readsKey1  = EdgeViewKey(RelationshipType("Person", "READS", "Book"),  ViewId(maybeSetSchema, List("readsView1")))
-    val readsKey2  = EdgeViewKey(RelationshipType("Person", "READS", "Book"),  ViewId(maybeSetSchema, List("readsView2")))
+    val bookKey = NodeViewKey(NodeType("Book"), ViewId(maybeSetSchema, List("bookView")))
+    val readsKey1 = EdgeViewKey(RelationshipType("Person", "READS", "Book"), ViewId(maybeSetSchema, List("readsView1")))
+    val readsKey2 = EdgeViewKey(RelationshipType("Person", "READS", "Book"), ViewId(maybeSetSchema, List("readsView2")))
 
     val expected = GraphDdl(
       Map(
@@ -200,79 +200,171 @@ class GraphDdlTest extends FunSpec with Matchers {
     )
   }
 
+  describe("validate EXTENDS syntax for mappings") {
+
+    val A_a = NodeViewKey(NodeType("A"), ViewId(Some(SetSchemaDefinition("ds1", "db1")), List("a")))
+    val A_ab = NodeViewKey(NodeType("A", "B"), ViewId(Some(SetSchemaDefinition("ds1", "db1")), List("a_b")))
+
+    val expectedGraph = Graph(
+      name = GraphName("myGraph"),
+      graphType = Schema.empty
+        .withNodePropertyKeys("A")("x" -> CTString)
+        .withNodePropertyKeys("A", "B")("x" -> CTString, "y" -> CTString)
+        .withRelationshipPropertyKeys("R")("y" -> CTString)
+        .withSchemaPatterns(SchemaPattern("A", "R", "A"))
+        .withSchemaPatterns(SchemaPattern(Set("A", "B"), "R", Set("A"))),
+      nodeToViewMappings = Map(
+        A_a -> NodeToViewMapping(NodeType("A"), ViewId(Some(SetSchemaDefinition("ds1", "db1")), List("a")), Map("x" -> "x")),
+        A_ab -> NodeToViewMapping(NodeType("A", "B"), ViewId(Some(SetSchemaDefinition("ds1", "db1")), List("a_b")), Map("x" -> "x", "y" -> "y"))
+      ),
+      edgeToViewMappings = List(
+        EdgeToViewMapping(RelationshipType("A", "R", "A"), ViewId(Some(SetSchemaDefinition("ds1", "db1")), List("r")),
+          StartNode(A_a, List(Join("id", "id"))),
+          EndNode(A_a, List(Join("id", "id"))),
+          Map("y" -> "y")
+        ),
+        EdgeToViewMapping(RelationshipType(NodeType("A", "B"), "R", NodeType("A")), ViewId(Some(SetSchemaDefinition("ds1", "db1")), List("r")),
+          StartNode(A_ab, List(Join("id", "id"))),
+          EndNode(A_a, List(Join("id", "id"))),
+          Map("y" -> "y")
+        )
+      )
+    )
+
+    it("allows compact inline graph definition with complex node type") {
+      val ddl = GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH myGraph (
+          |  A (x STRING),
+          |  B (y STRING),
+          |  R (y STRING),
+          |
+          |  (A)-[R]->(A),
+          |  (A, B)-[R]->(A),
+          |
+          |  (A) FROM a,
+          |  (A, B) FROM a_b,
+          |
+          |  (A)-[R]->(A) FROM r e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id,
+          |  (A, B)-[R]->(A) FROM r e
+          |    START NODES (A, B) FROM a_b n JOIN ON e.id = n.id
+          |    END   NODES (A)    FROM a   n JOIN ON e.id = n.id
+          |)
+        """.stripMargin)
+
+      ddl.graphs(GraphName("myGraph")) shouldEqual expectedGraph
+    }
+
+    it("allows compact inline graph definition with complex node type based on inheritance") {
+      val ddl = GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH myGraph (
+          |  A (x STRING),
+          |  B EXTENDS A (y STRING),
+          |  R (y STRING),
+          |
+          |  (A)-[R]->(A),
+          |  (B)-[R]->(A),
+          |
+          |  (A) FROM a,
+          |  (B) FROM a_b,
+          |
+          |  (A)-[R]->(A) FROM r e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id,
+          |  (B)-[R]->(A) FROM r e
+          |    START NODES (B) FROM a_b n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a   n JOIN ON e.id = n.id
+          |)
+        """.stripMargin)
+
+      ddl.graphs(GraphName("myGraph")) shouldEqual expectedGraph
+    }
+
+  }
+
+
   it("allows these equivalent graph definitions") {
     val ddls = List(
       // most compact form
-      GraphDdl("""SET SCHEMA ds1.db1
-                 |CREATE GRAPH myGraph (
-                 |  A (x STRING), B (y STRING),
-                 |  (A) FROM a,
-                 |  (A)-[B]->(A) FROM b e
-                 |    START NODES (A) FROM a n JOIN ON e.id = n.id
-                 |    END   NODES (A) FROM a n JOIN ON e.id = n.id
-                 |)
-               """.stripMargin),
+      GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH myGraph (
+          |  A (x STRING), B (y STRING),
+          |  (A) FROM a,
+          |  (A)-[B]->(A) FROM b e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id
+          |)
+        """.stripMargin),
       // mixed order
-      GraphDdl("""SET SCHEMA ds1.db1
-                 |CREATE GRAPH myGraph (
-                 |  (A)-[B]->(A) FROM b e
-                 |    START NODES (A) FROM a n JOIN ON e.id = n.id
-                 |    END   NODES (A) FROM a n JOIN ON e.id = n.id,
-                 |  A (x STRING), B (y STRING),
-                 |  (A) FROM a
-                 |)
-               """.stripMargin),
+      GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH myGraph (
+          |  (A)-[B]->(A) FROM b e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id,
+          |  A (x STRING), B (y STRING),
+          |  (A) FROM a
+          |)
+        """.stripMargin),
       // explicit node and rel type definition
-      GraphDdl("""SET SCHEMA ds1.db1
-                 |CREATE GRAPH myGraph (
-                 |  A (x STRING), B (y STRING),
-                 |  (A), (A)-[B]->(A),
-                 |  (A) FROM a,
-                 |  (A)-[B]->(A) FROM b e
-                 |    START NODES (A) FROM a n JOIN ON e.id = n.id
-                 |    END   NODES (A) FROM a n JOIN ON e.id = n.id
-                 |)
-               """.stripMargin),
+      GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH myGraph (
+          |  A (x STRING), B (y STRING),
+          |  (A), (A)-[B]->(A),
+          |  (A) FROM a,
+          |  (A)-[B]->(A) FROM b e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id
+          |)
+        """.stripMargin),
       // pure type definitions extracted to graph type
-      GraphDdl("""SET SCHEMA ds1.db1
-                 |CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (y STRING),
-                 |  (A), (A)-[B]->(A)
-                 |)
-                 |CREATE GRAPH myGraph OF myType (
-                 |  (A) FROM a,
-                 |  (A)-[B]->(A) FROM b e
-                 |    START NODES (A) FROM a n JOIN ON e.id = n.id
-                 |    END   NODES (A) FROM a n JOIN ON e.id = n.id
-                 |)
-               """.stripMargin),
+      GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (y STRING),
+          |  (A), (A)-[B]->(A)
+          |)
+          |CREATE GRAPH myGraph OF myType (
+          |  (A) FROM a,
+          |  (A)-[B]->(A) FROM b e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id
+          |)
+        """.stripMargin),
       // shadowing
-      GraphDdl("""SET SCHEMA ds1.db1
-                 |CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (foo STRING),
-                 |  (A), (A)-[B]->(A)
-                 |)
-                 |CREATE GRAPH myGraph OF myType (
-                 |  B (y STRING),
-                 |  (A) FROM a,
-                 |  (A)-[B]->(A) FROM b e
-                 |    START NODES (A) FROM a n JOIN ON e.id = n.id
-                 |    END   NODES (A) FROM a n JOIN ON e.id = n.id
-                 |)
-               """.stripMargin),
+      GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (foo STRING),
+          |  (A), (A)-[B]->(A)
+          |)
+          |CREATE GRAPH myGraph OF myType (
+          |  B (y STRING),
+          |  (A) FROM a,
+          |  (A)-[B]->(A) FROM b e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id
+          |)
+        """.stripMargin),
       // only label types in graph type
-      GraphDdl("""SET SCHEMA ds1.db1
-                 |CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (foo STRING)
-                 |)
-                 |CREATE GRAPH myGraph OF myType (
-                 |  B (y STRING),
-                 |  (A) FROM a,
-                 |  (A)-[B]->(A) FROM b e
-                 |    START NODES (A) FROM a n JOIN ON e.id = n.id
-                 |    END   NODES (A) FROM a n JOIN ON e.id = n.id
-                 |)
-               """.stripMargin)
+      GraphDdl(
+        """SET SCHEMA ds1.db1
+          |CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (foo STRING)
+          |)
+          |CREATE GRAPH myGraph OF myType (
+          |  B (y STRING),
+          |  (A) FROM a,
+          |  (A)-[B]->(A) FROM b e
+          |    START NODES (A) FROM a n JOIN ON e.id = n.id
+          |    END   NODES (A) FROM a n JOIN ON e.id = n.id
+          |)
+        """.stripMargin)
     )
 
     ddls(1) shouldEqual ddls.head
@@ -285,36 +377,40 @@ class GraphDdlTest extends FunSpec with Matchers {
   it("allows these equivalent graph type definitions") {
     val ddls = List(
       // most compact form
-      GraphDdl("""
-                 |CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (y STRING), C (z STRING),
-                 |  (A)-[B]->(C)
-                 |)
-                 |CREATE GRAPH myGraph OF myType ()
-               """.stripMargin),
+      GraphDdl(
+        """
+          |CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (y STRING), C (z STRING),
+          |  (A)-[B]->(C)
+          |)
+          |CREATE GRAPH myGraph OF myType ()
+        """.stripMargin),
       // explicit node and rel type definitions
-      GraphDdl("""CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (y STRING), C (z STRING),
-                 |  (A), (C),
-                 |  (A)-[B]->(C)
-                 |)
-                 |CREATE GRAPH myGraph OF myType ()
-               """.stripMargin),
+      GraphDdl(
+        """CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (y STRING), C (z STRING),
+          |  (A), (C),
+          |  (A)-[B]->(C)
+          |)
+          |CREATE GRAPH myGraph OF myType ()
+        """.stripMargin),
       // implicit node type definitions
-      GraphDdl("""CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (y STRING), C (z STRING),
-                 |  (A)-[B]->(C)
-                 |)
-                 |CREATE GRAPH myGraph OF myType ()
-               """.stripMargin),
+      GraphDdl(
+        """CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (y STRING), C (z STRING),
+          |  (A)-[B]->(C)
+          |)
+          |CREATE GRAPH myGraph OF myType ()
+        """.stripMargin),
       // shadowing
-      GraphDdl("""CREATE ELEMENT TYPE A (foo STRING)
-                 |CREATE GRAPH TYPE myType (
-                 |  A (x STRING), B (y STRING), C (z STRING),
-                 |  (A)-[B]->(C)
-                 |)
-                 |CREATE GRAPH myGraph OF myType ()
-               """.stripMargin)
+      GraphDdl(
+        """CREATE ELEMENT TYPE A (foo STRING)
+          |CREATE GRAPH TYPE myType (
+          |  A (x STRING), B (y STRING), C (z STRING),
+          |  (A)-[B]->(C)
+          |)
+          |CREATE GRAPH myGraph OF myType ()
+        """.stripMargin)
     )
 
     ddls(1) shouldEqual ddls.head
@@ -325,18 +421,19 @@ class GraphDdlTest extends FunSpec with Matchers {
   describe("failure handling") {
 
     it("fails on duplicate node mappings") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |SET SCHEMA db.schema
-        |
-        |CREATE GRAPH TYPE fooSchema (
-        | Person,
-        | (Person)
-        |)
-        |CREATE GRAPH fooGraph OF fooSchema (
-        |  (Person) FROM personView
-        |           FROM personView
-        |)
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |SET SCHEMA db.schema
+          |
+          |CREATE GRAPH TYPE fooSchema (
+          | Person,
+          | (Person)
+          |)
+          |CREATE GRAPH fooGraph OF fooSchema (
+          |  (Person) FROM personView
+          |           FROM personView
+          |)
+        """.stripMargin)
       e.getFullMessage should (include("fooGraph") and include("(Person)") and include("personView"))
     }
 
@@ -364,97 +461,106 @@ class GraphDdlTest extends FunSpec with Matchers {
     }
 
     it("fails on duplicate global labels") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE ELEMENT TYPE Person
-        |CREATE ELEMENT TYPE Person
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE ELEMENT TYPE Person
+          |CREATE ELEMENT TYPE Person
+        """.stripMargin)
       e.getFullMessage should include("Person")
     }
 
     it("fails on duplicate local labels") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH TYPE fooSchema (
-        | Person,
-        | Person
-        |)
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH TYPE fooSchema (
+          | Person,
+          | Person
+          |)
+        """.stripMargin)
       e.getFullMessage should (include("fooSchema") and include("Person"))
     }
 
     it("fails on duplicate graph types") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH TYPE fooSchema ()
-        |CREATE GRAPH TYPE fooSchema ()
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH TYPE fooSchema ()
+          |CREATE GRAPH TYPE fooSchema ()
+        """.stripMargin)
       e.getFullMessage should include("fooSchema")
     }
 
     it("fails on duplicate graphs") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH TYPE fooSchema ()
-        |CREATE GRAPH fooGraph OF fooSchema ()
-        |CREATE GRAPH fooGraph OF fooSchema ()
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH TYPE fooSchema ()
+          |CREATE GRAPH fooGraph OF fooSchema ()
+          |CREATE GRAPH fooGraph OF fooSchema ()
+        """.stripMargin)
       e.getFullMessage should include("fooGraph")
     }
 
     it("fails on unresolved graph type") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH TYPE fooSchema ()
-        |CREATE GRAPH fooGraph OF barSchema ()
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH TYPE fooSchema ()
+          |CREATE GRAPH fooGraph OF barSchema ()
+        """.stripMargin)
       e.getFullMessage should (include("fooGraph") and include("fooSchema") and include("barSchema"))
     }
 
     it("fails on unresolved labels") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH TYPE fooSchema (
-        | Person1,
-        | Person2,
-        | (Person3, Person4)
-        |)
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH TYPE fooSchema (
+          | Person1,
+          | Person2,
+          | (Person3, Person4)
+          |)
+        """.stripMargin)
       e.getFullMessage should (include("fooSchema") and include("Person3") and include("Person4"))
     }
 
     it("fails on unresolved labels in mapping") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH fooGraph (
-        | Person1,
-        | Person2,
-        | (Person3, Person4) FROM x
-        |)
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH fooGraph (
+          | Person1,
+          | Person2,
+          | (Person3, Person4) FROM x
+          |)
+        """.stripMargin)
       e.getFullMessage should (include("fooGraph") and include("Person3") and include("Person4"))
     }
 
     it("fails on incompatible property types") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |CREATE GRAPH TYPE fooSchema (
-        | Person1 ( age STRING ) ,
-        | Person2 ( age INTEGER ) ,
-        | (Person1, Person2)
-        |)
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |CREATE GRAPH TYPE fooSchema (
+          | Person1 ( age STRING ) ,
+          | Person2 ( age INTEGER ) ,
+          | (Person1, Person2)
+          |)
+        """.stripMargin)
       e.getFullMessage should (
-        include("fooSchema") and include("Person1") and include("Person2") and include("age") and include("STRING")  and include("INTEGER")
-      )
+                              include("fooSchema") and include("Person1") and include("Person2") and include("age") and include("STRING") and include("INTEGER")
+                              )
     }
 
     it("fails on unresolved property names") {
-      val e = the [GraphDdlException] thrownBy GraphDdl("""
-        |SET SCHEMA a.b
-        |CREATE GRAPH TYPE fooSchema (
-        | Person ( age1 STRING ) ,
-        | (Person)
-        |)
-        |CREATE GRAPH fooGraph OF fooSchema (
-        |  (Person) FROM personView ( person_name AS age2 )
-        |)
-      """.stripMargin)
+      val e = the[GraphDdlException] thrownBy GraphDdl(
+        """
+          |SET SCHEMA a.b
+          |CREATE GRAPH TYPE fooSchema (
+          | Person ( age1 STRING ) ,
+          | (Person)
+          |)
+          |CREATE GRAPH fooGraph OF fooSchema (
+          |  (Person) FROM personView ( person_name AS age2 )
+          |)
+        """.stripMargin)
       e.getFullMessage should (
-        include("fooGraph") and include("Person") and include("personView") and include("age1")  and include("age2")
-      )
+                              include("fooGraph") and include("Person") and include("personView") and include("age1") and include("age2")
+                              )
     }
   }
 }


### PR DESCRIPTION
This introduces `EXTENDS` syntax as in the following example:

```
A ( a STRING ),
B ( b STRING ),
C EXTENDS A ( c STRING ),
D EXTENDS A, B ( d STRING ),

(A), -- resolves to LabelSet (A)
(B), -- resolves to LabelSet (B)
(C), -- resolves to LabelSet (A, C)
(D), -- resolves to LabelSet (A, B, D)
```
We still support the previous syntax, e.g. given the above element types it is valid to write:

```
(A, B), -- resolves to LabelSet (A, B)
(C, D), -- resolves to LabelSet (A, B, C, D)
```

