### PR TITLE
Add Gradle task to run custom Scala app

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ The above program prints:
 
 More examples, including [multiple graph features](spark-cypher-examples/src/main/scala/org/opencypher/spark/examples/MultipleGraphExample.scala), can be found [in the examples module](spark-cypher-examples).
 
+### Run example Scala apps via command line
+
+You can use Gradle to run a specific Scala application from command line. For example, to run the `CaseClassExample` 
+within the `spark-cypher-examples` module, we just call:
+
+```
+./gradlew spark-cypher-examples:runApp -PmainClass=org.opencypher.spark.examples.CaseClassExample
+```
+
 ### Loading CSV Data
 
 See the documentation in `org.opencypher.spark.impl.io.hdfs.CsvGraphLoader`, which specifies how to structure the

--- a/build.gradle
+++ b/build.gradle
@@ -83,11 +83,16 @@ subprojects {
         group 'help'
     }
 
-    task runApp(type:JavaExec) {
+    task runApp {
+        dependsOn tasks.compileScala
         group 'run'
         description 'Run a custom Scala app (use -PmainClass=path.to.App)'
-        main = project.hasProperty("mainClass") ? project.getProperty("mainClass") : ""
-        classpath = sourceSets.main.runtimeClasspath
+        doLast {
+            project.javaexec {
+                classpath = sourceSets.main.runtimeClasspath
+                main = project.getProperty("mainClass")
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,11 @@ subprojects {
     }
 
     task runApp {
-        dependsOn tasks.compileScala
+        dependsOn tasks.classes
         group 'run'
-        description 'Run a custom Scala app (use -PmainClass=path.to.App)'
+        description 'Run a custom Scala app (use -PmainClass=com.my.package.App)'
         doLast {
-            project.javaexec {
+            javaexec {
                 classpath = sourceSets.main.runtimeClasspath
                 main = project.getProperty("mainClass")
             }

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,13 @@ subprojects {
         description 'Searches all projects for a dependency'
         group 'help'
     }
+
+    task runApp(type:JavaExec) {
+        group 'run'
+        description 'Run a custom Scala app (use -PmainClass=path.to.App)'
+        main = project.hasProperty("mainClass") ? project.getProperty("mainClass") : ""
+        classpath = sourceSets.main.runtimeClasspath
+    }
 }
 
 apply from: 'build.licenses.gradle'


### PR DESCRIPTION
Allows you to do:
`./gradlew spark-cypher-examples:runApp -PmainClass=org.opencypher.spark.examples.CaseClassExample`

@tobias-johansson maybe you know a better way. I tried the `application` plugin but that also requires passing a system property.