### PR TITLE
Change group id for documentation artifacts subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 apply from: 'build.params.gradle'
+apply plugin: 'base'
 
 allprojects {
     group   = 'org.opencypher'

--- a/build.publishing.gradle
+++ b/build.publishing.gradle
@@ -47,13 +47,17 @@ subprojects {
                 from components.java
 
                 afterEvaluate {
-                    ['sourceJar',
-                     'docJar',
-                     'testJar',
-                     'asciidocJar',
-                     'shadowJar']
+                    def included = [
+                            'jar',
+                            'sourceJar',
+                            'docJar',
+                            'testJar',
+                            'asciidocJar',
+                            'shadowJar'
+                    ]
+                    artifacts = included
                             .findResults { tasks.findByName(it) }
-                            .each { artifact it }
+                            .findAll { it.enabled }
                 }
 
                 pom {

--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -1,6 +1,13 @@
+group = group + '.documentation'
+
 task asciidocJar(type: Jar) {
     group 'documentation'
     description 'Package asciidoc source files.'
     classifier = 'asciidoc'
     from("asciidoc")
 }
+
+tasks.sourceJar.enabled = false
+tasks.testJar.enabled = false
+tasks.docJar.enabled = false
+tasks.jar.enabled = false


### PR DESCRIPTION
Group id for docs is now `org.opencypher.documentation` and this
subproject does not produce jar, sources-jar, tests-jar or
javadoc-jar anymore (these were empty anyway).

The new group id enables filtering the artifacts away from the
real code artifacts.

Co-authored-by: Tobias Johansson <tobias.johansson@neotechnology.com>
Co-authored-by: Jonatan Jäderberg <jonatan.jaderberg@gmail.com>