### PR TITLE
Towards a more readable TOC

### DIFF
--- a/documentation/asciidoc/architecture-and-usage.adoc
+++ b/documentation/asciidoc/architecture-and-usage.adoc
@@ -1,5 +1,5 @@
 [[technology]]
-= Technology choices and future directions
+= Technology choices
 
 [abstract]
 --
@@ -24,7 +24,7 @@ This suggests several possible future directions:
 
 
 [[technology-distributed-vs-federated]]
-== Distributed vs. federated query processing
+== Query processing
 
 In choosing data sources and sinks, where the data resides is pretty important.
 

--- a/documentation/asciidoc/backend-filesystem.adoc
+++ b/documentation/asciidoc/backend-filesystem.adoc
@@ -1,5 +1,5 @@
 [[backend-filesystem]]
-= Filesystem Backend
+= Filesystem
 
 [abstract]
 --

--- a/documentation/asciidoc/backend-in-memory.adoc
+++ b/documentation/asciidoc/backend-in-memory.adoc
@@ -1,5 +1,5 @@
 [[backend-in-memory]]
-= In-memory backend
+= In-memory
 
 [abstract]
 --

--- a/documentation/asciidoc/backend-neo4j.adoc
+++ b/documentation/asciidoc/backend-neo4j.adoc
@@ -1,5 +1,5 @@
 [[backend-neo4j]]
-= Neo4j Backend
+= Neo4j
 
 [abstract]
 --

--- a/documentation/asciidoc/backend-sql.adoc
+++ b/documentation/asciidoc/backend-sql.adoc
@@ -1,5 +1,5 @@
 [[backend-sql]]
-= SQL Backend
+= SQL
 
 [abstract]
 --

--- a/documentation/asciidoc/caching-and-performance.adoc
+++ b/documentation/asciidoc/caching-and-performance.adoc
@@ -1,5 +1,5 @@
 [[caching-and-performance]]
-= Caching and performance
+= Performance
 
 [abstract]
 --
@@ -13,7 +13,7 @@ This article contains some general guidelines on how caching is used with Spark:
 
 
 [[caching-and-performance-table-caching]]
-== Option 1 - Cache the backing table
+== Cache the backing table
 
 CAPS graphs are generally backed by tables that contain nodes/relationships, which are in turn implemented by Spark tables.
 The underlying Spark tables can be cached like this:
@@ -28,7 +28,7 @@ Alternatively, you can call `.persist()` on the Spark table and specify a storag
 
 
 [[caching-and-performance-graph-caching]]
-== Option 2 - Cache the entire graph
+== Cache the graph
 
 [source, scala]
 ----

--- a/documentation/asciidoc/cypher-cypher9-features.adoc
+++ b/documentation/asciidoc/cypher-cypher9-features.adoc
@@ -1,5 +1,5 @@
 [[cypher-cypher9-features]]
-= Supported subset of Cypher
+= Supported Cypher
 
 // TODO: Incorporate below spreadsheet here
 // https://docs.google.com/spreadsheets/d/1c5_LoI96EYICE6l09rxna-eLO7V-GParEdiHLJJ_Oaw/[This spreadsheet] tracks which aspects of Cypher are currently supported.

--- a/documentation/asciidoc/cypher-multiple-graphs.adoc
+++ b/documentation/asciidoc/cypher-multiple-graphs.adoc
@@ -1,5 +1,5 @@
 [[cypher-multiple-graphs]]
-= Multiple-Graph support for Cypher
+= Multiple-Graph support
 
 [abstract]
 --

--- a/documentation/asciidoc/cypher.adoc
+++ b/documentation/asciidoc/cypher.adoc
@@ -11,7 +11,7 @@ For the Cypher 9 specification and other openCypher language resources, see the 
 
 
 [[cypher-sparksql]]
-== Cypher runs on top of Spark SQL
+== Cypher on Spark SQL
 
 The CAPS layer essentially translates Cypher queries into Spark SQL operators.
 As a result, certain aspects of Cypher like `USING INDEX` would not make sense to support in the Spark world.
@@ -19,7 +19,7 @@ Additionally, other functions like `lower()` and `upper()` can easily be duplica
 
 
 [[cypher-limitations]]
-== Create and read only
+== Limitations
 
 Because of the Spark programming model, CAPS does not support updates and deletes.
 The general approach should be to take one data source or graph, transform it into another, and store that.

--- a/documentation/asciidoc/examples/caps/case-class.adoc
+++ b/documentation/asciidoc/examples/caps/case-class.adoc
@@ -1,5 +1,5 @@
 [[example-case-class]]
-= Example: Case class
+= Case class
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/census-sql-hive.adoc
+++ b/documentation/asciidoc/examples/caps/census-sql-hive.adoc
@@ -1,5 +1,5 @@
 [[example-census-sql-hive]]
-= Example: Census SQL graph source example using Hive
+= Census SQL graph source example using Hive
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/census-sql-jdbc.adoc
+++ b/documentation/asciidoc/examples/caps/census-sql-jdbc.adoc
@@ -1,5 +1,5 @@
 [[example-census-sql-jdbc]]
-= Example: Census SQL graph source example using JDBC
+= Census SQL graph source example using JDBC
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/custom-dataframe-input.adoc
+++ b/documentation/asciidoc/examples/caps/custom-dataframe-input.adoc
@@ -1,5 +1,5 @@
 [[example-custom-dataframe-input]]
-= Example: Custom DataFrame input
+= Custom DataFrame input
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/cypher-sql-roundtrip.adoc
+++ b/documentation/asciidoc/examples/caps/cypher-sql-roundtrip.adoc
@@ -1,5 +1,5 @@
 [[example-cypher-sql-roundtrip]]
-= Example: Cypher-SQL round-trip
+= Cypher-SQL round-trip
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/dataframe-input.adoc
+++ b/documentation/asciidoc/examples/caps/dataframe-input.adoc
@@ -1,5 +1,5 @@
 [[example-dataframe-input]]
-= Example: DataFrame input
+= DataFrame input
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/dataframe-output.adoc
+++ b/documentation/asciidoc/examples/caps/dataframe-output.adoc
@@ -1,5 +1,5 @@
 [[example-dataframe-output]]
-= Example: DataFrame output
+= DataFrame output
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/datasource.adoc
+++ b/documentation/asciidoc/examples/caps/datasource.adoc
@@ -1,5 +1,5 @@
 [[example-datasource]]
-= Example: DataSource
+= DataSource
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/details.adoc
+++ b/documentation/asciidoc/examples/caps/details.adoc
@@ -1,5 +1,5 @@
 [[example-detail]]
-= Example: detailed, custom DataFrame input
+= Detailed, custom DataFrame input
 
 [abstract]
 --

--- a/documentation/asciidoc/examples/caps/graph-views.adoc
+++ b/documentation/asciidoc/examples/caps/graph-views.adoc
@@ -1,5 +1,5 @@
 [[example-graph-views]]
-= Example: Graph views
+= Graph views
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/graphx-pagerank.adoc
+++ b/documentation/asciidoc/examples/caps/graphx-pagerank.adoc
@@ -1,5 +1,5 @@
 [[example-graphx-pagerank]]
-= Example: GraphX PageRank
+= GraphX PageRank
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/multiple-graphs.adoc
+++ b/documentation/asciidoc/examples/caps/multiple-graphs.adoc
@@ -1,5 +1,5 @@
 [[example-multiple-graphs]]
-= Example: Multiple-Graphs
+= Multiple-Graphs
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/neo4j-graph-merge.adoc
+++ b/documentation/asciidoc/examples/caps/neo4j-graph-merge.adoc
@@ -1,5 +1,5 @@
 [[example-neo4j-graph-merge]]
-= Example: Neo4j GraphMerge
+= Neo4j GraphMerge
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/neo4j-workflow.adoc
+++ b/documentation/asciidoc/examples/caps/neo4j-workflow.adoc
@@ -1,5 +1,5 @@
 [[example-neo4j-workflow]]
-= Example: Neo4j workflow
+= Neo4j workflow
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/northwind-sql-jdbc.adoc
+++ b/documentation/asciidoc/examples/caps/northwind-sql-jdbc.adoc
@@ -1,5 +1,5 @@
 [[example-northwind-sql-jdbc]]
-= Example: Northwind SQL graph source example using JDBC
+= Northwind SQL graph source example using JDBC
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/recommendation.adoc
+++ b/documentation/asciidoc/examples/caps/recommendation.adoc
@@ -1,5 +1,5 @@
 [[example-recommendation]]
-= Example: recommendation
+= Recommendation
 
 [source, scala]
 ----

--- a/documentation/asciidoc/examples/caps/update.adoc
+++ b/documentation/asciidoc/examples/caps/update.adoc
@@ -1,5 +1,5 @@
 [[example-update]]
-= Example: update
+= Update
 
 [source, scala]
 ----

--- a/documentation/asciidoc/introduction.adoc
+++ b/documentation/asciidoc/introduction.adoc
@@ -23,7 +23,7 @@ To understand this, we start with the "tables for labels" model.
 
 
 [[graphs-from-tables-model]]
-== The "tables for labels" model
+== Tables for labels
 
 "Tables for labels" refers to a way of formatting tabular data such that the mapping to a graph is straightforward and easy.
 To describe this briefly, it means that all nodes for the same combination of labels and all relationships with the same type are stored in their own table.
@@ -116,7 +116,7 @@ This allows to define different properties for `:Customer` and `:Employee`.
 
 
 [[graph-from-tables-definition]]
-== Defining a graph from a set of tables
+== Defining a graph
 
 Given a set of tables, there are two ways to convert them to a graph:
 
@@ -129,11 +129,11 @@ If the data is denormalised and does not contain unique identifiers, then we rec
 
 
 [[graph-from-tables-scala-api]]
-== Defining a graph using the Scala API
+=== Scala API
 
 
 [[graphs-from-tables-data-preparation]]
-=== Preparing your data
+==== Preparing your data
 
 The recommended way to convert complex tables into graphs is to use the SQL PGDS with the Graph DDL.
 
@@ -145,7 +145,7 @@ For the next step, we assume that you have `DataFrame`s that are in the "tables 
 
 
 [[graphs-from-tables-graph-mappings]]
-=== Express graph mappings
+==== Express graph mappings
 
 To manually define the graph mapping for tables we can use the Scala API.
 Graph mappings allow CAPS to map rows in DataFrames to nodes or relationships.
@@ -175,7 +175,7 @@ These mappings allow to interpret tables as a graph.
 
 
 [[graphs-from-tables-entity-tables]]
-=== Create CAPS tables, and then the graph
+==== Create CAPS tables, and then the graph
 
 We combine the mappings with the tables in order to create node and relationship tables:
 
@@ -191,7 +191,7 @@ Now we have everything we need to run Cypher queries on our newly defined graph.
 
 
 [[graph-from-tables-graph-ddl]]
-== Defining a graph using Graph DDL
+=== Graph DDL
 
 The Graph DDL is a language to describe a mapping from a set of relational tables and views to a graph.
 


### PR DESCRIPTION
If we could take advantage of title abbreviations[1], we could use a long-form title in the running narrative and an abbreviated title in the TOC. Our docs tooling doesn't currently support this, unfortunately.

[1]: https://tdg.docbook.org/tdg/5.1/titleabbrev.html