### PR TITLE
Report error message when property has unsupported Cypher type

### DIFF
--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/SparkSQLExprMapper.scala
@@ -145,7 +145,7 @@ object SparkSQLExprMapper {
           functions.array(exprs.map(_.asSparkSQLExpr): _*)
 
         case NullLit(ct) =>
-          NULL_LIT.cast(ct.toSparkType.get)
+          NULL_LIT.cast(ct.getSparkType)
 
         case LocalDateTime(dateExpr) =>
           dateExpr match {


### PR DESCRIPTION
This is first found by the :C node in the test because it lacks the
property which is typed ANY