### PR TITLE
Produce correct tables in SQL PGDS acceptance tests

### DIFF
--- a/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdl.scala
+++ b/graph-ddl/src/main/scala/org/opencypher/graphddl/GraphDdl.scala
@@ -471,6 +471,15 @@ case class ViewId(maybeSetSchema: Option[SetSchemaDefinition], parts: List[Strin
       case _ => malformed("Relative view identifier requires a preceding SET SCHEMA statement", parts.mkString("."))
     }
   }
+
+  lazy val tableName: String = (maybeSetSchema, parts) match {
+    case (_, _ :: schema :: view :: Nil) => s"$schema.$view"
+    case (Some(SetSchemaDefinition(_, schema)), view :: Nil) => s"$schema.$view"
+    case (None, view) if view.size < 3 =>
+      malformed("Relative view identifier requires a preceding SET SCHEMA statement", view.mkString("."))
+    case (Some(_), view) if view.size > 1 =>
+      malformed("Relative view identifier must have exactly one segment", view.mkString("."))
+  }
 }
 
 sealed trait ElementToViewMapping

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/FullPGDSAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/FullPGDSAcceptanceTest.scala
@@ -62,11 +62,7 @@ class FullPGDSAcceptanceTest extends CAPSTestSuite
 
   executeScenariosWithContext(allScenarios, SessionContextFactory)
 
-  val sqlBlackList: Set[String] = Set.empty
-
-  allSqlContextFactories.foreach(ctx =>
-    executeScenariosWithContext(allScenarios.filter(s => !sqlBlackList.contains(s.name)), ctx)
-  )
+  allSqlContextFactories.foreach(executeScenariosWithContext(allScenarios, _))
 
   allFileSystemContextFactories.foreach(executeScenariosWithContext(allScenarios, _))
 

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/FullPGDSAcceptanceTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/api/io/FullPGDSAcceptanceTest.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.junit.rules.TemporaryFolder
 import org.opencypher.graphddl
-import org.opencypher.graphddl.Graph
+import org.opencypher.graphddl.{Graph, NodeToViewMapping, NodeViewKey}
 import org.opencypher.okapi.api.graph.GraphName
 import org.opencypher.okapi.api.io.PropertyGraphDataSource
 import org.opencypher.okapi.impl.io.SessionGraphDataSource
@@ -41,7 +41,6 @@ import org.opencypher.okapi.neo4j.io.MetaLabelSupport
 import org.opencypher.okapi.neo4j.io.testing.Neo4jServerFixture
 import org.opencypher.spark.api.FSGraphSources.FSGraphSourceFactory
 import org.opencypher.spark.api.io.FileFormat._
-import org.opencypher.spark.api.io.fs.DefaultGraphDirectoryStructure.nodeTableDirectoryName
 import org.opencypher.spark.api.io.sql.IdGenerationStrategy._
 import org.opencypher.spark.api.io.sql.SqlDataSourceConfig.Hive
 import org.opencypher.spark.api.io.sql.util.DdlUtils._
@@ -63,7 +62,7 @@ class FullPGDSAcceptanceTest extends CAPSTestSuite
 
   executeScenariosWithContext(allScenarios, SessionContextFactory)
 
-  val sqlBlackList: Set[String] = Set("API: PropertyGraphDataSource: correct node/rel count for graph #1")
+  val sqlBlackList: Set[String] = Set.empty
 
   allSqlContextFactories.foreach(ctx =>
     executeScenariosWithContext(allScenarios.filter(s => !sqlBlackList.contains(s.name)), ctx)
@@ -211,18 +210,34 @@ class FullPGDSAcceptanceTest extends CAPSTestSuite
     override def initPgds(graphNames: List[GraphName]): SqlPropertyGraphDataSource = {
       val ddls = graphNames.map { gn =>
         val g = graph(gn)
-        val schema = g.schema
-        schema.labelCombinations.combos.foreach { labelCombination =>
-          val nodeDf = g.canonicalNodeTable(labelCombination).removePrefix(propertyPrefix)
-          val tableName = databaseName + "." + nodeTableDirectoryName(labelCombination)
-          writeTable(nodeDf, tableName)
+        val ddl = g.defaultDdl(gn, Some(dataSourceName), Some(databaseName))
+
+        ddl.graphs(gn).nodeToViewMappings.foreach { case (key: NodeViewKey, mapping: NodeToViewMapping) =>
+          val nodeDf = g.canonicalNodeTable(key.nodeType.elementTypes).removePrefix(propertyPrefix)
+          writeTable(nodeDf, mapping.view.tableName)
         }
-        schema.relationshipTypes.foreach { relType =>
-          val relDf = g.canonicalRelationshipTable(relType).removePrefix(propertyPrefix)
-          val tableName = databaseName + "." + relType
-          writeTable(relDf, tableName)
+
+        ddl.graphs(gn).edgeToViewMappings.foreach { edgeToViewMapping =>
+          val startNodeDf = g.canonicalNodeTable(edgeToViewMapping.relType.startNodeType.elementTypes)
+          val endNodeDf = g.canonicalNodeTable(edgeToViewMapping.relType.endNodeType.elementTypes)
+          val allRelsDf = g.canonicalRelationshipTable(edgeToViewMapping.key.relType.elementType).removePrefix(propertyPrefix)
+          val relDfColumns = allRelsDf.columns.toSeq
+
+          val tmpNodeId = s"node_${GraphEntity.sourceIdKey}"
+          val tmpStartNodeDf = startNodeDf.withColumnRenamed(GraphEntity.sourceIdKey, tmpNodeId)
+          val tmpEndNodeDf = endNodeDf.withColumnRenamed(GraphEntity.sourceIdKey, tmpNodeId)
+
+          val startNodesWithRelsDf = tmpStartNodeDf
+            .join(allRelsDf, tmpStartNodeDf.col(tmpNodeId) === allRelsDf.col(Relationship.sourceStartNodeKey))
+            .select(relDfColumns.head, relDfColumns.tail: _*)
+
+          val relsDf = startNodesWithRelsDf
+            .join(tmpEndNodeDf, startNodesWithRelsDf.col(Relationship.sourceEndNodeKey) === tmpEndNodeDf.col(tmpNodeId))
+            .select(relDfColumns.head, relDfColumns.tail: _*)
+
+          writeTable(relsDf, edgeToViewMapping.view.tableName)
         }
-        g.defaultDdl(gn, Some(dataSourceName), Some(databaseName))
+        ddl
       }
       val ddl = ddls.foldLeft(graphddl.GraphDdl(Map.empty[GraphName, Graph]))(_ ++ _)
       SqlPropertyGraphDataSource(ddl, Map(dataSourceName -> sqlDataSourceConfig), idGenerationStrategy)

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/fs/GraphDirectoryStructure.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/fs/GraphDirectoryStructure.scala
@@ -73,12 +73,13 @@ object DefaultGraphDirectoryStructure {
     if (labels.isEmpty) {
       noLabelNodeDirectoryName
     } else {
-      labels.toSeq.sorted.mkString("_").encodeSpecialCharacters
+      concatDirectoryNames(labels.toSeq.sorted)
     }
   }
 
   def relKeyTableDirectoryName(relKey: String): String = relKey.encodeSpecialCharacters
 
+  def concatDirectoryNames(seq: Seq[String]): String = seq.mkString("_").encodeSpecialCharacters
 }
 
 case class DefaultGraphDirectoryStructure(dataSourceRootPath: String) extends GraphDirectoryStructure {

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/fs/GraphDirectoryStructure.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/fs/GraphDirectoryStructure.scala
@@ -69,17 +69,17 @@ object DefaultGraphDirectoryStructure {
   // Because an empty path does not work, we need a special directory name for nodes without labels.
   val noLabelNodeDirectoryName: String = "__NO_LABEL__"
 
-  def nodeTableDirectoryName(labels: Set[String]): String = {
-    if (labels.isEmpty) {
-      noLabelNodeDirectoryName
-    } else {
-      concatDirectoryNames(labels.toSeq.sorted)
-    }
-  }
+  def nodeTableDirectoryName(labels: Set[String]): String = concatDirectoryNames(labels.toSeq.sorted)
 
   def relKeyTableDirectoryName(relKey: String): String = relKey.encodeSpecialCharacters
 
-  def concatDirectoryNames(seq: Seq[String]): String = seq.mkString("_").encodeSpecialCharacters
+  def concatDirectoryNames(seq: Seq[String]): String = {
+    if (seq.isEmpty) {
+      noLabelNodeDirectoryName
+    } else {
+      seq.mkString("_").encodeSpecialCharacters
+    }
+  }
 }
 
 case class DefaultGraphDirectoryStructure(dataSourceRootPath: String) extends GraphDirectoryStructure {

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
@@ -28,14 +28,13 @@ package org.opencypher.spark.api.io.sql
 
 import java.net.URI
 
-import org.apache.spark.sql.types.DateType
 import org.apache.spark.sql.{DataFrame, DataFrameReader, functions}
 import org.opencypher.graphddl.GraphDdl.PropertyMappings
 import org.opencypher.graphddl._
 import org.opencypher.okapi.api.graph.{GraphName, PropertyGraph}
 import org.opencypher.okapi.api.io.conversion.{EntityMapping, NodeMappingBuilder, RelationshipMappingBuilder}
 import org.opencypher.okapi.api.schema.Schema
-import org.opencypher.okapi.api.types.{CTDate, CypherType}
+import org.opencypher.okapi.api.types.CypherType
 import org.opencypher.okapi.impl.exception.{GraphNotFoundException, IllegalArgumentException, UnsupportedOperationException}
 import org.opencypher.okapi.impl.util.StringEncodingUtilities._
 import org.opencypher.spark.api.CAPSSession
@@ -202,7 +201,7 @@ case class SqlPropertyGraphDataSource(
       case (_, column) => throw IllegalArgumentException(
         expected = s"Column with name $column",
         actual = indexedFields)
-    }
+    }.toMap
     val renamedDf = dataFrame.safeRenameColumns(columnRenamings)
     val columnCasts = columnTypes.map { case (columnName, cypherType) =>
       renamedDf.col(columnRenamings.getOrElse(columnName, columnName)) -> cypherType.getSparkType

--- a/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/api/io/sql/SqlPropertyGraphDataSource.scala
@@ -205,11 +205,7 @@ case class SqlPropertyGraphDataSource(
     }
     val renamedDf = dataFrame.safeRenameColumns(columnRenamings)
     val columnCasts = columnTypes.map { case (columnName, cypherType) =>
-      val sparkType = cypherType match {
-        case CTDate => DateType
-        case other => other.getSparkType
-      }
-      renamedDf.col(columnRenamings.getOrElse(columnName, columnName)) -> sparkType
+      renamedDf.col(columnRenamings.getOrElse(columnName, columnName)) -> cypherType.getSparkType
     }
     renamedDf.transformColumns(columnTypes.keys.toSeq: _*)(column => column.cast(columnCasts(column)))
   }


### PR DESCRIPTION
The previous logic created a table for each reltype (e.g. `R`) according
to the OKAPI schema. However, `(A)-[R]->(B) `and `(A)-[R]->(C)` are
different rel types in DDL/SQL PGDS world. We therefore need to create
tables for each DDL rel Type in order to create non-overlapping input
tables. This is achieved by joining relation tables with their incident
node tables to get the actual relationships.