### PR TITLE
Rewrite neo4j launcher tasks

### DIFF
--- a/okapi-neo4j-io-testing/build.gradle
+++ b/okapi-neo4j-io-testing/build.gradle
@@ -1,3 +1,6 @@
+import ch.kk7.gradle.spawn.KillTask
+import ch.kk7.gradle.spawn.SpawnTask
+
 apply plugin: 'ch.kk7.spawn'
 
 description = 'Okapi - Neo4j IO test utils'
@@ -16,50 +19,45 @@ dependencies {
     servicesCompile group: 'org.neo4j.test', name: 'neo4j-harness-enterprise', version: ver.neo4j.harness
 }
 
+def neo4jLauncher(String launcher, int instances, String starter, String stopper, String status) {
+    task(starter, type: SpawnTask) {
+        description "Launches $launcher (x$instances) in a separate JVM"
+        group "services"
 
-def neo4jStartedMarker() { 'neo4j started' }
+        dependsOn project.sourceSets.services.runtimeClasspath
 
-def neo4jCommandLine(int instances) {
-    def java = System.getProperty('java.home') + '/bin/java'
-    def classpath = sourceSets.services.runtimeClasspath.collect { it.absolutePath }.join(':')
-    def main = 'org.opencypher.testing.services.Neo4j'
-    return [java, '-cp', classpath, main, neo4jStartedMarker(), instances.toString()]
+        String java = System.getProperty('java.home') + '/bin/java'
+        String classpath = project.sourceSets.services.runtimeClasspath.collect { it.absolutePath }.join(':')
+        String main = "org.opencypher.testing.services.$launcher"
+        String marker = 'neo4j started'
+
+        commandLine = [java, '-cp', classpath, main, marker, instances.toString()]
+        waitFor     = marker
+        doLast { println getStdoutFile().text }
+    }
+
+    task(stopper, type: KillTask) {
+        description "Stops $launcher"
+        group "services"
+        kills tasks[starter]
+    }
+
+    task(status) {
+        description "Prints status on $launcher"
+        group "services"
+        doLast {
+            def res = [pid: 'unknown', status: 'unknown']
+            if (tasks[starter].pidFile.exists()) {
+                res.pid    = tasks[starter].pidFile.text
+                res.status = tasks[starter].kill('-0', res.pid) ? 'running' : 'stopped'
+            }
+            println res
+        }
+    }
 }
 
-task neo4jStart(type: ch.kk7.gradle.spawn.SpawnTask) {
-    description "Launches a Neo4j instance in a separate JVM."
-    group "services"
-
-    dependsOn sourceSets.services.runtimeClasspath
-
-    commandLine = neo4jCommandLine(1)
-    waitFor     = neo4jStartedMarker()
-    doLast { println getStdoutFile().text }
-}
-
-task neo4jStop(type: ch.kk7.gradle.spawn.KillTask) {
-    description "Stops Neo4j instances started by 'neo4jStart'."
-    group "services"
-    kills tasks.neo4jStart
-}
-
-
-task neo4jStartTwoInstances(type: ch.kk7.gradle.spawn.SpawnTask) {
-    description "Launches two Neo4j instances in a separate JVM (used for examples)."
-    group "services"
-
-    dependsOn sourceSets.services.runtimeClasspath
-
-    commandLine = neo4jCommandLine(2)
-    waitFor     = neo4jStartedMarker()
-    doLast { println getStdoutFile().text }
-}
-
-task neo4jStopTwoInstances(type: ch.kk7.gradle.spawn.KillTask) {
-    description "Stops Neo4j instances started by 'neo4jStartTwoInstances'."
-    group "services"
-    kills tasks.neo4jStartTwoInstances
-}
+neo4jLauncher('Neo4jEnterprise', 1, 'neo4jStart', 'neo4jStop', 'neo4jStatus')
+neo4jLauncher('Neo4jCommunity', 2, 'neo4jStartTwoInstances', 'neo4jStopTwoInstances', 'neo4jStatusTwoInstances')
 
 tasks.test.dependsOn(tasks.neo4jStart)
 tasks.test.finalizedBy(tasks.neo4jStop)

--- a/okapi-neo4j-io-testing/src/services/scala/org/opencypher/testing/services/Neo4jCommunity.scala
+++ b/okapi-neo4j-io-testing/src/services/scala/org/opencypher/testing/services/Neo4jCommunity.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2019 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.testing.services
+
+import org.neo4j.harness.{TestServerBuilder, TestServerBuilders}
+
+
+object Neo4jCommunity extends Neo4jLauncher {
+  override def builder: TestServerBuilder = TestServerBuilders.newInProcessBuilder()
+}

--- a/okapi-neo4j-io-testing/src/services/scala/org/opencypher/testing/services/Neo4jEnterprise.scala
+++ b/okapi-neo4j-io-testing/src/services/scala/org/opencypher/testing/services/Neo4jEnterprise.scala
@@ -26,23 +26,8 @@
  */
 package org.opencypher.testing.services
 
-import org.neo4j.harness.EnterpriseTestServerBuilders
+import org.neo4j.harness.{EnterpriseTestServerBuilders, TestServerBuilder}
 
-object Neo4j extends App {
-  val Array(marker, instances) = args
-
-  Range(0, instances.toInt).foreach { i =>
-    val bolt = 7687 + i
-    val http = 7474 + i
-    val server = EnterpriseTestServerBuilders.newInProcessBuilder()
-      .withConfig("dbms.connector.bolt.listen_address", s"127.0.0.1:$bolt")
-      .withConfig("dbms.connector.http.listen_address", s"127.0.0.1:$http")
-      .newServer()
-
-    println(s"bolt: ${server.boltURI()}")
-    println(s"http: ${server.httpURI()}")
-  }
-
-  println(marker)
-
+object Neo4jEnterprise extends Neo4jLauncher {
+  override def builder: TestServerBuilder = EnterpriseTestServerBuilders.newInProcessBuilder()
 }

--- a/okapi-neo4j-io-testing/src/services/scala/org/opencypher/testing/services/Neo4jLauncher.scala
+++ b/okapi-neo4j-io-testing/src/services/scala/org/opencypher/testing/services/Neo4jLauncher.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2019 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.testing.services
+
+import org.neo4j.harness.TestServerBuilder
+
+trait Neo4jLauncher {
+
+  def builder: TestServerBuilder
+
+  def main(args: Array[String]): Unit = {
+    val Array(marker, instances) = args
+
+    Range(0, instances.toInt).foreach { i =>
+      val bolt = 7687 + i
+      val http = 7474 + i
+      val server = builder
+        .withConfig("dbms.connector.bolt.listen_address", s"127.0.0.1:$bolt")
+        .withConfig("dbms.connector.http.listen_address", s"127.0.0.1:$http")
+        .newServer()
+
+      println(s"bolt: ${server.boltURI()}")
+      println(s"http: ${server.httpURI()}")
+    }
+
+    println(marker)
+  }
+}


### PR DESCRIPTION
- Enterprise fails if instances > 1, so launch Community in that case
- Extract tasks into method for code sharing
- Add status task