### PR TITLE
Adjust AcceptanceTest Generator to new TCK-API version

### DIFF
--- a/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/AcceptanceTestGenerator.scala
+++ b/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/AcceptanceTestGenerator.scala
@@ -115,8 +115,8 @@ case class AcceptanceTestGenerator(
          | */
          |package $targetPackageName.${packageName.get}
          |
-         |import org.scalatest.junit.JUnitRunner
          |import org.junit.runner.RunWith
+         |import org.scalatestplus.junit.JUnitRunner
          |import scala.util.{Failure, Success, Try}
          |import org.opencypher.okapi.api.value.CypherValue._
          |import org.opencypher.okapi.testing.propertygraph.InMemoryTestGraph

--- a/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/AcceptanceTestGenerator.scala
+++ b/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/AcceptanceTestGenerator.scala
@@ -115,8 +115,6 @@ case class AcceptanceTestGenerator(
          | */
          |package $targetPackageName.${packageName.get}
          |
-         |import org.junit.runner.RunWith
-         |import org.scalatestplus.junit.JUnitRunner
          |import scala.util.{Failure, Success, Try}
          |import org.opencypher.okapi.api.value.CypherValue._
          |import org.opencypher.okapi.testing.propertygraph.InMemoryTestGraph
@@ -131,7 +129,6 @@ case class AcceptanceTestGenerator(
          |           CypherPropertyMap => TCKCypherPropertyMap, CypherNull => TCKCypherNull, CypherPath => TCKCypherPath}
          |${specificImports.mkString("\n")}
          |
-         |@RunWith(classOf[JUnitRunner])
          |class $className extends $testSuiteName{
          |
          |$testCases

--- a/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/CreateStringGenerator.scala
+++ b/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/CreateStringGenerator.scala
@@ -51,8 +51,19 @@ object CreateStringGenerator {
           case _ => s"TCKCypherValue.apply(${escapeString(l.toString)}, false)"
         }
       case TCKCypherNull => "TCKCypherNull"
-      case TCKCypherNode(labels, properties) => s"TCKCypherNode(Set(${labels.map(escapeString).mkString(",")}), ${tckCypherValueToCreateString(properties)})"
-      case TCKCypherRelationship(typ, properties) => s"TCKCypherRelationship(${escapeString(typ)}, ${tckCypherValueToCreateString(properties)})"
+      case TCKCypherNode(labels, properties) =>
+        val labelsString = if (labels.isEmpty) "" else s"Set(${labels.map(escapeString).mkString(",")})"
+        val propertyString = if (properties.properties.isEmpty) "" else s"${tckCypherValueToCreateString(properties)}"
+        val separatorString =
+          if (labels.isEmpty && properties.properties.isEmpty) ""
+          else if (labels.isEmpty) "properties = "
+          else if (properties.properties.isEmpty) ""
+          else ", "
+
+        s"TCKCypherNode($labelsString$separatorString$propertyString)"
+      case TCKCypherRelationship(typ, properties) =>
+        val propertyString = if (properties.properties.isEmpty) "" else s", ${tckCypherValueToCreateString(properties)}"
+        s"TCKCypherRelationship(${escapeString(typ)}$propertyString)"
       case TCKCypherPath(start, connections) =>
         val connectionsCreateString = connections.map {
           case TCKForward(r, n) => s"TCKForward(${tckCypherValueToCreateString(r)},${tckCypherValueToCreateString(n)})"
@@ -93,8 +104,8 @@ object CreateStringGenerator {
     s"CypherMap(${mapElementsString.mkString(",")})"
   }
 
-  def diffToCreateString(diff : Diff): String = {
-    val diffs = diff.v.map{case (s,i) => escapeString(s) -> i}
+  def diffToCreateString(diff: Diff): String = {
+    val diffs = diff.v.map { case (s, i) => escapeString(s) -> i }
     s"Diff(Map(${diffs.mkString(",")}}))"
   }
 

--- a/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/CreateStringGenerator.scala
+++ b/okapi-tck/src/main/scala/org/opencypher/okapi/tck/test/CreateStringGenerator.scala
@@ -55,9 +55,8 @@ object CreateStringGenerator {
         val labelsString = if (labels.isEmpty) "" else s"Set(${labels.map(escapeString).mkString(",")})"
         val propertyString = if (properties.properties.isEmpty) "" else s"${tckCypherValueToCreateString(properties)}"
         val separatorString =
-          if (labels.isEmpty && properties.properties.isEmpty) ""
+          if (properties.properties.isEmpty) ""
           else if (labels.isEmpty) "properties = "
-          else if (properties.properties.isEmpty) ""
           else ", "
 
         s"TCKCypherNode($labelsString$separatorString$propertyString)"


### PR DESCRIPTION
Due to the updated TCK API dependency, some generated Test couldn't not compile anymore. (Problem with empty constructors)
The solution improves the creation of construct-strings for TCKCypherNode and TCKCypherRelationship. 
For instance node with no labels and no properties now leads to _TCKCypherNode()_ instead of _TCKCypherNode(Set(), TCKCypherPropertyMap(Map()))_