### PR TITLE
Consistency of @RunWith annotation  

### DIFF
--- a/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/CAPSTestSuite.scala
+++ b/spark-cypher-testing/src/main/scala/org/opencypher/spark/testing/CAPSTestSuite.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.spark.testing
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.graph.QualifiedGraphName
 import org.opencypher.okapi.relational.api.graph.RelationalCypherGraph
 import org.opencypher.okapi.relational.api.planning.RelationalRuntimeContext
@@ -34,9 +33,7 @@ import org.opencypher.okapi.testing.BaseTestSuite
 import org.opencypher.spark.impl.table.SparkTable.DataFrameTable
 import org.opencypher.spark.testing.fixture.{CAPSSessionFixture, SparkSessionFixture}
 import org.opencypher.spark.testing.support.{GraphMatchingTestSupport, RecordMatchingTestSupport}
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 abstract class CAPSTestSuite
     extends BaseTestSuite
     with SparkSessionFixture

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/UnionGraphTest.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/UnionGraphTest.scala
@@ -27,18 +27,10 @@
 package org.opencypher.spark.impl
 
 import org.apache.spark.sql.Row
-import org.junit.runner.RunWith
-import org.opencypher.okapi.api.graph.GraphName
-import org.opencypher.okapi.impl.exception.SchemaException
-import org.opencypher.okapi.ir.api.configuration.IrConfiguration.PrintIr
-import org.opencypher.okapi.logical.api.configuration.LogicalConfiguration.PrintLogicalPlan
-import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.{PrintOptimizedRelationalPlan, PrintRelationalPlan}
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.api.value.CAPSEntity._
 import org.opencypher.spark.testing.fixture.{GraphConstructionFixture, RecordsVerificationFixture, TeamDataFixture}
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class UnionGraphTest extends CAPSGraphTest
   with GraphConstructionFixture
   with RecordsVerificationFixture

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/AggregationTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/AggregationTests.scala
@@ -26,14 +26,11 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class AggregationTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("AVG") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/BoundedVarExpandTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/BoundedVarExpandTests.scala
@@ -26,14 +26,11 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.api.value.CAPSRelationship
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class BoundedVarExpandTests extends CAPSTestSuite with ScanGraphInit {
 
   it("explicitly bound to zero length") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/CacheTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/CacheTests.scala
@@ -26,14 +26,11 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.graph.CypherResult
 import org.opencypher.okapi.relational.impl.operators.Cache
 import org.opencypher.spark.impl.CAPSConverters._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CacheTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("scan caching") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/CatalogDDLTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/CatalogDDLTests.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.graph.{GraphName, QualifiedGraphName}
 import org.opencypher.okapi.api.types.CTNode
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
@@ -35,9 +34,7 @@ import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.testing.CAPSTestSuite
 import org.opencypher.v9_0.util.SyntaxException
 import org.scalatest.BeforeAndAfterAll
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CatalogDDLTests extends CAPSTestSuite with ScanGraphInit with BeforeAndAfterAll {
 
   override def afterEach(): Unit = {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/DrivingTableTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/DrivingTableTests.scala
@@ -30,17 +30,12 @@ import java.util
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.impl.CAPSRecords
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class DrivingTableTests extends CAPSTestSuite with ScanGraphInit {
-
-  import scala.collection.JavaConverters._
 
   val data: util.List[Row] = List(
     Row(10, "Alice"),

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ExpandIntoTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ExpandIntoTests.scala
@@ -26,13 +26,10 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ExpandIntoTests extends CAPSTestSuite with ScanGraphInit {
 
   it("test expand into for dangling edge") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ExpressionTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ExpressionTests.scala
@@ -27,7 +27,6 @@
 package org.opencypher.spark.impl.acceptance
 
 import claimant.Claim
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue
 import org.opencypher.okapi.api.value.CypherValue.Format.defaultValueFormatter
 import org.opencypher.okapi.api.value.CypherValue.{CypherFloat, CypherInteger, CypherList, CypherMap}
@@ -40,10 +39,8 @@ import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.impl.SparkSQLMappingException
 import org.opencypher.spark.testing.CAPSTestSuite
 import org.scalacheck.Prop
-import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 
-@RunWith(classOf[JUnitRunner])
 class ExpressionTests extends CAPSTestSuite with ScanGraphInit with Checkers {
 
   describe("list slice") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/FunctionTests.scala
@@ -26,17 +26,14 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
-import org.opencypher.okapi.api.value.CypherValue.{CypherList, CypherMap, CypherNull}
+import org.opencypher.okapi.api.value.CypherValue.{CypherMap, CypherNull}
 import org.opencypher.okapi.impl.exception.NotImplementedException
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.api.value.CAPSEntity._
 import org.opencypher.spark.api.value.CAPSNode
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class FunctionTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("Acos") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/MatchTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/MatchTests.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.impl.exception.IllegalArgumentException
@@ -34,9 +33,7 @@ import org.opencypher.okapi.relational.impl.graph.ScanGraph
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class MatchTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("match on empty graphs / table") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/MultipleGraphTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/MultipleGraphTests.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.schema.{PropertyKeys, Schema}
 import org.opencypher.okapi.api.types.{CTInteger, CTString}
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
@@ -41,11 +40,9 @@ import org.opencypher.spark.impl.CAPSConverters._
 import org.opencypher.spark.impl.table.SparkTable
 import org.opencypher.spark.schema.CAPSSchema._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
 import scala.language.existentials
 
-@RunWith(classOf[JUnitRunner])
 class MultipleGraphTests extends CAPSTestSuite with ScanGraphInit {
 
   def testGraph1: RelationalCypherGraph[SparkTable.DataFrameTable] = initGraph("CREATE (:Person {name: 'Mats'})")

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/NullTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/NullTests.scala
@@ -26,13 +26,10 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.testing.{Bag, TestNameFixture}
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class NullTests extends CAPSTestSuite with ScanGraphInit with TestNameFixture {
 
   override protected def separator: String = "calling:"

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/OptionalMatchTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/OptionalMatchTests.scala
@@ -26,7 +26,6 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.schema.Schema
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.relational.impl.graph.ScanGraph
@@ -34,9 +33,7 @@ import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.api.value.CAPSNode
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class OptionalMatchTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("match on empty graph / table") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/PatternScanTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/PatternScanTests.scala
@@ -26,15 +26,12 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.graph.{NodeRelPattern, TripletPattern}
 import org.opencypher.okapi.api.types.{CTNode, CTRelationship}
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class PatternScanTests extends CAPSTestSuite with ScanGraphInit {
 
   it("resolves simple expands") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/PredicateTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/PredicateTests.scala
@@ -33,7 +33,6 @@ import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.testing.CAPSTestSuite
 import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class PredicateTests extends CAPSTestSuite with ScanGraphInit {
 
   it("can evaluate predicates on non-existing properties") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/PredicateTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/PredicateTests.scala
@@ -26,12 +26,10 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
 class PredicateTests extends CAPSTestSuite with ScanGraphInit {
 

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ReturnTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/ReturnTests.scala
@@ -27,7 +27,6 @@
 package org.opencypher.spark.impl.acceptance
 
 import org.apache.spark.sql.Row
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.testing.Bag
@@ -36,9 +35,7 @@ import org.opencypher.spark.api.value.CAPSEntity._
 import org.opencypher.spark.api.value.{CAPSNode, CAPSRelationship}
 import org.opencypher.spark.impl.CAPSConverters._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ReturnTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("RETURN") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/TemporalTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/TemporalTests.scala
@@ -29,15 +29,12 @@ package org.opencypher.spark.impl.acceptance
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.impl.exception.{IllegalArgumentException, IllegalStateException, UnsupportedOperationException}
 import org.opencypher.okapi.impl.temporal.Duration
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class TemporalTests extends CAPSTestSuite with ScanGraphInit {
   private def shouldParseDate(given: String, expected: String): Unit = {
     caps.cypher(s"RETURN date('$given') AS time").records.toMaps should equal(

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/UnionTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/UnionTests.scala
@@ -26,8 +26,6 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
-import org.opencypher.okapi.api.graph.GraphName
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.impl.exception.SchemaException
 import org.opencypher.okapi.ir.api.configuration.IrConfiguration.PrintIr
@@ -36,9 +34,7 @@ import org.opencypher.okapi.relational.api.configuration.CoraConfiguration.Print
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.api.value.{CAPSNode, CAPSRelationship}
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class UnionTests extends CAPSTestSuite with ScanGraphInit {
 
   describe("tabular union all") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/UnionTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/UnionTests.scala
@@ -26,6 +26,7 @@
  */
 package org.opencypher.spark.impl.acceptance
 
+import org.opencypher.okapi.api.graph.GraphName
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.impl.exception.SchemaException
 import org.opencypher.okapi.ir.api.configuration.IrConfiguration.PrintIr

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/UnwindTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/UnwindTests.scala
@@ -26,14 +26,11 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue.{CypherMap, _}
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.spark.api.value.CAPSNode
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class UnwindTests extends CAPSTestSuite with ScanGraphInit {
 
   it("standalone unwind from parameter") {

--- a/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/WithTests.scala
+++ b/spark-cypher-testing/src/test/scala/org/opencypher/spark/impl/acceptance/WithTests.scala
@@ -26,15 +26,12 @@
  */
 package org.opencypher.spark.impl.acceptance
 
-import org.junit.runner.RunWith
 import org.opencypher.okapi.api.value.CypherValue._
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 import org.opencypher.spark.impl.CAPSConverters._
 import org.opencypher.spark.testing.CAPSTestSuite
-import org.scalatestplus.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class WithTests extends CAPSTestSuite with ScanGraphInit {
 
   test("rebinding of dropped variables") {


### PR DESCRIPTION
Removes redundant _RunWith_ annotations for test classes, which get already inherit this annotation. 